### PR TITLE
Sprint 2: Implement Search + Route Navigation Features

### DIFF
--- a/Navigation/Navigation/Coordinator/AppCoordinator.swift
+++ b/Navigation/Navigation/Coordinator/AppCoordinator.swift
@@ -1,4 +1,7 @@
 import UIKit
+import MapKit
+import Combine
+import CoreLocation
 
 final class AppCoordinator: Coordinator {
 
@@ -11,12 +14,20 @@ final class AppCoordinator: Coordinator {
 
     private let window: UIWindow
     private let locationService: LocationService
+    private let searchService: SearchService
+    private let routeService: RouteService
+
+    private var mapViewController: MapViewController!
+    private var homeViewController: HomeViewController!
+    private var currentDrawer: SearchResultDrawerViewController?
 
     // MARK: - Init
 
     init(window: UIWindow) {
         self.window = window
         self.locationService = .shared
+        self.searchService = SearchService()
+        self.routeService = RouteService()
         self.navigationController = UINavigationController()
         self.navigationController.isNavigationBarHidden = true
     }
@@ -24,16 +35,194 @@ final class AppCoordinator: Coordinator {
     // MARK: - Start
 
     func start() {
-        let mapViewController = MapViewController(locationService: locationService)
-        let homeViewModel = HomeViewModel(locationService: locationService)
-        let homeViewController = HomeViewController(
-            viewModel: homeViewModel,
-            mapViewController: mapViewController
-        )
+        let mapVC = MapViewController(locationService: locationService)
+        self.mapViewController = mapVC
 
-        navigationController.setViewControllers([homeViewController], animated: false)
+        let homeViewModel = HomeViewModel(locationService: locationService)
+        let homeVC = HomeViewController(
+            viewModel: homeViewModel,
+            mapViewController: mapVC
+        )
+        self.homeViewController = homeVC
+
+        homeVC.onSearchBarTapped = { [weak self] in
+            self?.showSearch()
+        }
+
+        navigationController.setViewControllers([homeVC], animated: false)
 
         window.rootViewController = navigationController
         window.makeKeyAndVisible()
+    }
+
+    // MARK: - Search Flow
+
+    private func showSearch() {
+        let searchViewModel = SearchViewModel(
+            searchService: searchService
+        )
+        let searchVC = SearchViewController(viewModel: searchViewModel)
+        searchVC.modalPresentationStyle = .fullScreen
+
+        searchVC.onDismiss = { [weak self] in
+            self?.navigationController.dismiss(animated: true)
+        }
+
+        searchVC.onSearchResults = { [weak self] results in
+            self?.navigationController.dismiss(animated: true) {
+                self?.showSearchResults(results)
+            }
+        }
+
+        navigationController.present(searchVC, animated: true)
+    }
+
+    private func showSearchResults(_ results: [MKMapItem]) {
+        // Show markers on map
+        mapViewController.showSearchResults(results)
+
+        // Create drawer
+        let drawerVC = SearchResultDrawerViewController()
+        drawerVC.updateResults(results)
+        currentDrawer = drawerVC
+
+        // Drawer → Map sync: item tapped → show route preview
+        drawerVC.onItemSelected = { [weak self] mapItem, _ in
+            self?.showRoutePreview(to: mapItem)
+        }
+
+        // Drawer → Map sync: scroll changes focused annotation
+        drawerVC.onFocusedIndexChanged = { [weak self] index in
+            self?.mapViewController.focusAnnotation(at: index)
+        }
+
+        // Map → Drawer sync: annotation tapped → scroll drawer
+        mapViewController.onAnnotationSelected = { [weak self] index in
+            self?.currentDrawer?.scrollToIndex(index)
+        }
+
+        // Present as sheet
+        if let sheet = drawerVC.sheetPresentationController {
+            let smallDetent = UISheetPresentationController.Detent.custom(identifier: .init("small")) { _ in
+                return 200
+            }
+            let mediumDetent = UISheetPresentationController.Detent.medium()
+            let largeDetent = UISheetPresentationController.Detent.large()
+
+            sheet.detents = [smallDetent, mediumDetent, largeDetent]
+            sheet.selectedDetentIdentifier = .init("small")
+            sheet.prefersGrabberVisible = true
+            sheet.largestUndimmedDetentIdentifier = largeDetent.identifier
+            sheet.prefersScrollingExpandsWhenScrolledToEdge = true
+        }
+
+        navigationController.present(drawerVC, animated: true)
+    }
+
+    // MARK: - Route Preview Flow
+
+    private func showRoutePreview(to mapItem: MKMapItem) {
+        // Dismiss drawer
+        currentDrawer?.dismiss(animated: true) { [weak self] in
+            self?.currentDrawer = nil
+        }
+
+        // Clear search markers
+        mapViewController.clearSearchResults()
+
+        // Show destination pin
+        let coordinate = mapItem.location.coordinate
+        let subtitle = mapItem.address?.shortAddress ?? mapItem.address?.fullAddress
+        mapViewController.showDestination(
+            coordinate: coordinate,
+            title: mapItem.name,
+            subtitle: subtitle
+        )
+
+        // Get current user location
+        let userCoordinate = locationService.locationPublisher.value?.coordinate
+            ?? CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780) // Seoul fallback
+
+        // Move map to child of RoutePreviewVC
+        moveMapToRoutePreview(
+            origin: userCoordinate,
+            destination: coordinate,
+            destinationName: mapItem.name
+        )
+    }
+
+    private func moveMapToRoutePreview(
+        origin: CLLocationCoordinate2D,
+        destination: CLLocationCoordinate2D,
+        destinationName: String?
+    ) {
+        // Remove map from Home
+        mapViewController.willMove(toParent: nil)
+        mapViewController.view.removeFromSuperview()
+        mapViewController.removeFromParent()
+
+        // Create RoutePreview
+        let routePreviewVM = RoutePreviewViewModel(
+            routeService: routeService,
+            origin: origin,
+            destination: destination,
+            destinationName: destinationName
+        )
+
+        let routePreviewVC = RoutePreviewViewController(
+            viewModel: routePreviewVM,
+            mapViewController: mapViewController
+        )
+
+        routePreviewVC.onDismiss = { [weak self] in
+            self?.dismissRoutePreview()
+        }
+
+        routePreviewVC.onStartNavigation = { [weak self] route in
+            self?.startNavigation(with: route)
+        }
+
+        navigationController.pushViewController(routePreviewVC, animated: true)
+    }
+
+    private func dismissRoutePreview() {
+        // Pop RoutePreviewVC
+        navigationController.popViewController(animated: true)
+
+        // Return map to Home
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+            guard let self else { return }
+            self.returnMapToHome()
+        }
+    }
+
+    private func returnMapToHome() {
+        // Remove map from any parent
+        mapViewController.willMove(toParent: nil)
+        mapViewController.view.removeFromSuperview()
+        mapViewController.removeFromParent()
+
+        // Re-add to Home
+        homeViewController.addChild(mapViewController)
+        homeViewController.view.insertSubview(mapViewController.view, at: 0)
+        mapViewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            mapViewController.view.topAnchor.constraint(equalTo: homeViewController.view.topAnchor),
+            mapViewController.view.leadingAnchor.constraint(equalTo: homeViewController.view.leadingAnchor),
+            mapViewController.view.trailingAnchor.constraint(equalTo: homeViewController.view.trailingAnchor),
+            mapViewController.view.bottomAnchor.constraint(equalTo: homeViewController.view.bottomAnchor),
+        ])
+
+        mapViewController.didMove(toParent: homeViewController)
+    }
+
+    // MARK: - Navigation (Sprint 3 Stub)
+
+    private func startNavigation(with route: MKRoute) {
+        print("🧭 [Sprint 3] Start navigation with route: \(route.name)")
+        print("   Distance: \(route.formattedDistance)")
+        print("   ETA: \(route.formattedTravelTime)")
+        print("   Steps: \(route.steps.count)")
     }
 }

--- a/Navigation/Navigation/Feature/Home/HomeViewController.swift
+++ b/Navigation/Navigation/Feature/Home/HomeViewController.swift
@@ -41,6 +41,8 @@ final class HomeViewController: UIViewController {
     private let mapViewController: MapViewController
     private var cancellables = Set<AnyCancellable>()
 
+    var onSearchBarTapped: (() -> Void)?
+
     // MARK: - Init
 
     init(viewModel: HomeViewModel, mapViewController: MapViewController) {
@@ -112,6 +114,14 @@ final class HomeViewController: UIViewController {
                 equalTo: searchBarContainer.trailingAnchor, constant: -Theme.Spacing.md
             ),
         ])
+
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(searchBarTapped))
+        searchBarContainer.addGestureRecognizer(tapGesture)
+        searchBarContainer.isUserInteractionEnabled = true
+    }
+
+    @objc private func searchBarTapped() {
+        onSearchBarTapped?()
     }
 
     // MARK: - Binding

--- a/Navigation/Navigation/Feature/RoutePreview/RouteOptionCell.swift
+++ b/Navigation/Navigation/Feature/RoutePreview/RouteOptionCell.swift
@@ -1,0 +1,106 @@
+import UIKit
+import MapKit
+
+final class RouteOptionCell: UITableViewCell {
+
+    // MARK: - UI Components
+
+    private let transportIcon: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.image = UIImage(systemName: "car.fill")
+        return imageView
+    }()
+
+    private let timeLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Theme.Fonts.headline
+        return label
+    }()
+
+    private let distanceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Theme.Fonts.subheadline
+        label.textColor = Theme.Colors.secondaryLabel
+        return label
+    }()
+
+    private let arrivalLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Theme.Fonts.footnote
+        label.textColor = Theme.Colors.secondaryLabel
+        return label
+    }()
+
+    private let checkmark: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: "checkmark.circle.fill")
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        backgroundColor = .clear
+        selectionStyle = .none
+
+        contentView.addSubview(transportIcon)
+        contentView.addSubview(timeLabel)
+        contentView.addSubview(distanceLabel)
+        contentView.addSubview(arrivalLabel)
+        contentView.addSubview(checkmark)
+
+        NSLayoutConstraint.activate([
+            transportIcon.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Theme.Spacing.lg),
+            transportIcon.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            transportIcon.widthAnchor.constraint(equalToConstant: 24),
+            transportIcon.heightAnchor.constraint(equalToConstant: 24),
+
+            timeLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Theme.Spacing.md),
+            timeLabel.leadingAnchor.constraint(equalTo: transportIcon.trailingAnchor, constant: Theme.Spacing.md),
+
+            distanceLabel.leadingAnchor.constraint(equalTo: timeLabel.trailingAnchor, constant: Theme.Spacing.sm),
+            distanceLabel.lastBaselineAnchor.constraint(equalTo: timeLabel.lastBaselineAnchor),
+
+            arrivalLabel.topAnchor.constraint(equalTo: timeLabel.bottomAnchor, constant: Theme.Spacing.xs),
+            arrivalLabel.leadingAnchor.constraint(equalTo: timeLabel.leadingAnchor),
+            arrivalLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Theme.Spacing.md),
+
+            checkmark.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            checkmark.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Theme.Spacing.lg),
+            checkmark.widthAnchor.constraint(equalToConstant: 24),
+            checkmark.heightAnchor.constraint(equalToConstant: 24),
+        ])
+    }
+
+    // MARK: - Configure
+
+    func configure(with route: MKRoute, isSelected: Bool) {
+        timeLabel.text = route.formattedTravelTime
+        distanceLabel.text = route.formattedDistance
+        arrivalLabel.text = route.formattedArrivalTime
+
+        let color = isSelected ? Theme.Colors.primary : Theme.Colors.secondaryLabel
+        transportIcon.tintColor = color
+        timeLabel.textColor = isSelected ? Theme.Colors.primary : Theme.Colors.label
+        checkmark.isHidden = !isSelected
+        checkmark.tintColor = Theme.Colors.primary
+    }
+}

--- a/Navigation/Navigation/Feature/RoutePreview/RoutePreviewViewController.swift
+++ b/Navigation/Navigation/Feature/RoutePreview/RoutePreviewViewController.swift
@@ -1,0 +1,273 @@
+import UIKit
+import Combine
+import MapKit
+
+final class RoutePreviewViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let backButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        button.tintColor = Theme.Colors.label
+        button.backgroundColor = Theme.Colors.secondaryBackground
+        button.layer.cornerRadius = 20
+        button.layer.shadowColor = Theme.Shadow.color
+        button.layer.shadowOpacity = Theme.Shadow.opacity
+        button.layer.shadowOffset = Theme.Shadow.offset
+        button.layer.shadowRadius = Theme.Shadow.radius
+        return button
+    }()
+
+    private let bottomContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = Theme.Colors.background
+        view.layer.cornerRadius = Theme.CornerRadius.large
+        view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        view.layer.shadowColor = Theme.Shadow.color
+        view.layer.shadowOpacity = Theme.Shadow.opacity
+        view.layer.shadowOffset = CGSize(width: 0, height: -2)
+        view.layer.shadowRadius = Theme.Shadow.radius
+        return view
+    }()
+
+    private let destinationLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Theme.Fonts.headline
+        label.textColor = Theme.Colors.label
+        return label
+    }()
+
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = .clear
+        tableView.separatorStyle = .none
+        tableView.isScrollEnabled = false
+        return tableView
+    }()
+
+    private let startButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("안내 시작", for: .normal)
+        button.titleLabel?.font = Theme.Fonts.headline
+        button.backgroundColor = Theme.Colors.primary
+        button.setTitleColor(.white, for: .normal)
+        button.layer.cornerRadius = Theme.CornerRadius.medium
+        return button
+    }()
+
+    private let loadingIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicator.hidesWhenStopped = true
+        return indicator
+    }()
+
+    // MARK: - Properties
+
+    private let viewModel: RoutePreviewViewModel
+    private let mapViewController: MapViewController
+    private var cancellables = Set<AnyCancellable>()
+
+    var onStartNavigation: ((MKRoute) -> Void)?
+    var onDismiss: (() -> Void)?
+
+    // MARK: - Init
+
+    init(viewModel: RoutePreviewViewModel, mapViewController: MapViewController) {
+        self.viewModel = viewModel
+        self.mapViewController = mapViewController
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupMapChild()
+        setupUI()
+        setupTableView()
+        setupActions()
+        bindViewModel()
+
+        destinationLabel.text = viewModel.destinationName ?? "목적지"
+
+        Task {
+            await viewModel.calculateRoutes()
+        }
+    }
+
+    // MARK: - Setup
+
+    private func setupMapChild() {
+        addChild(mapViewController)
+        view.addSubview(mapViewController.view)
+        mapViewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            mapViewController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            mapViewController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            mapViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mapViewController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        mapViewController.didMove(toParent: self)
+    }
+
+    private func setupUI() {
+        view.backgroundColor = Theme.Colors.background
+
+        view.addSubview(backButton)
+        view.addSubview(bottomContainer)
+        bottomContainer.addSubview(destinationLabel)
+        bottomContainer.addSubview(tableView)
+        bottomContainer.addSubview(startButton)
+        bottomContainer.addSubview(loadingIndicator)
+
+        NSLayoutConstraint.activate([
+            backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Theme.Spacing.sm),
+            backButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Theme.Spacing.lg),
+            backButton.widthAnchor.constraint(equalToConstant: 40),
+            backButton.heightAnchor.constraint(equalToConstant: 40),
+
+            bottomContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomContainer.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            destinationLabel.topAnchor.constraint(equalTo: bottomContainer.topAnchor, constant: Theme.Spacing.xl),
+            destinationLabel.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor, constant: Theme.Spacing.lg),
+            destinationLabel.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor, constant: -Theme.Spacing.lg),
+
+            tableView.topAnchor.constraint(equalTo: destinationLabel.bottomAnchor, constant: Theme.Spacing.md),
+            tableView.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor),
+            tableView.heightAnchor.constraint(equalToConstant: 180),
+
+            startButton.topAnchor.constraint(equalTo: tableView.bottomAnchor, constant: Theme.Spacing.md),
+            startButton.leadingAnchor.constraint(equalTo: bottomContainer.leadingAnchor, constant: Theme.Spacing.lg),
+            startButton.trailingAnchor.constraint(equalTo: bottomContainer.trailingAnchor, constant: -Theme.Spacing.lg),
+            startButton.heightAnchor.constraint(equalToConstant: 56),
+            startButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -Theme.Spacing.lg),
+
+            loadingIndicator.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: tableView.centerYAnchor),
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(RouteOptionCell.self, forCellReuseIdentifier: "RouteOptionCell")
+    }
+
+    private func setupActions() {
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+        startButton.addTarget(self, action: #selector(startNavigationTapped), for: .touchUpInside)
+    }
+
+    // MARK: - Binding
+
+    private func bindViewModel() {
+        viewModel.routes
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] routes in
+                guard let self else { return }
+                tableView.reloadData()
+                if !routes.isEmpty {
+                    mapViewController.showRoutes(routes, selectedIndex: viewModel.selectedRouteIndex.value)
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.selectedRouteIndex
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] index in
+                guard let self else { return }
+                tableView.reloadData()
+                let routes = viewModel.routes.value
+                if !routes.isEmpty {
+                    mapViewController.showRoutes(routes, selectedIndex: index)
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.isCalculating
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isCalc in
+                if isCalc {
+                    self?.loadingIndicator.startAnimating()
+                    self?.startButton.isEnabled = false
+                    self?.startButton.alpha = 0.5
+                } else {
+                    self?.loadingIndicator.stopAnimating()
+                    self?.startButton.isEnabled = true
+                    self?.startButton.alpha = 1.0
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.errorMessage
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .default))
+                self?.present(alert, animated: true)
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Actions
+
+    @objc private func backTapped() {
+        mapViewController.clearRoutes()
+        mapViewController.clearDestination()
+        onDismiss?()
+    }
+
+    @objc private func startNavigationTapped() {
+        guard let selectedRoute = viewModel.getSelectedRoute() else { return }
+        onStartNavigation?(selectedRoute)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension RoutePreviewViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.routes.value.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: "RouteOptionCell",
+            for: indexPath
+        ) as? RouteOptionCell else {
+            return UITableViewCell()
+        }
+
+        let route = viewModel.routes.value[indexPath.row]
+        let isSelected = indexPath.row == viewModel.selectedRouteIndex.value
+        cell.configure(with: route, isSelected: isSelected)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension RoutePreviewViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        viewModel.selectRoute(at: indexPath.row)
+    }
+}

--- a/Navigation/Navigation/Feature/RoutePreview/RoutePreviewViewModel.swift
+++ b/Navigation/Navigation/Feature/RoutePreview/RoutePreviewViewModel.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Combine
+import MapKit
+import CoreLocation
+
+final class RoutePreviewViewModel {
+
+    // MARK: - Publishers
+
+    let routes = CurrentValueSubject<[MKRoute], Never>([])
+    let selectedRouteIndex = CurrentValueSubject<Int, Never>(0)
+    let isCalculating = CurrentValueSubject<Bool, Never>(false)
+    let errorMessage = CurrentValueSubject<String?, Never>(nil)
+
+    // MARK: - Properties
+
+    let destinationName: String?
+
+    // MARK: - Private
+
+    private let routeService: RouteService
+    private let origin: CLLocationCoordinate2D
+    private let destination: CLLocationCoordinate2D
+    private let transportMode: TransportMode
+
+    // MARK: - Init
+
+    init(
+        routeService: RouteService,
+        origin: CLLocationCoordinate2D,
+        destination: CLLocationCoordinate2D,
+        destinationName: String?,
+        transportMode: TransportMode = .automobile
+    ) {
+        self.routeService = routeService
+        self.origin = origin
+        self.destination = destination
+        self.destinationName = destinationName
+        self.transportMode = transportMode
+    }
+
+    // MARK: - Actions
+
+    func calculateRoutes() async {
+        isCalculating.send(true)
+        errorMessage.send(nil)
+
+        do {
+            let calculatedRoutes = try await routeService.calculateRoutes(
+                from: origin,
+                to: destination,
+                transportType: transportMode.mkTransportType
+            )
+            routes.send(calculatedRoutes)
+        } catch {
+            errorMessage.send(error.localizedDescription)
+        }
+
+        isCalculating.send(false)
+    }
+
+    func selectRoute(at index: Int) {
+        guard index < routes.value.count else { return }
+        selectedRouteIndex.send(index)
+    }
+
+    func getSelectedRoute() -> MKRoute? {
+        let index = selectedRouteIndex.value
+        guard index < routes.value.count else { return nil }
+        return routes.value[index]
+    }
+}

--- a/Navigation/Navigation/Feature/Search/DrawerListFocusTracker.swift
+++ b/Navigation/Navigation/Feature/Search/DrawerListFocusTracker.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class DrawerListFocusTracker {
+
+    private var debounceTimer: Timer?
+    private let debounceInterval: TimeInterval = 0.15
+    private var lastNotifiedIndex: Int = -1
+
+    var onIndexChanged: ((Int) -> Void)?
+
+    func notifyScroll(toIndex index: Int) {
+        guard index != lastNotifiedIndex else { return }
+
+        debounceTimer?.invalidate()
+        debounceTimer = Timer.scheduledTimer(withTimeInterval: debounceInterval, repeats: false) { [weak self] _ in
+            self?.lastNotifiedIndex = index
+            self?.onIndexChanged?(index)
+        }
+    }
+
+    func reset() {
+        debounceTimer?.invalidate()
+        debounceTimer = nil
+        lastNotifiedIndex = -1
+    }
+}

--- a/Navigation/Navigation/Feature/Search/SearchResultCell.swift
+++ b/Navigation/Navigation/Feature/Search/SearchResultCell.swift
@@ -1,0 +1,77 @@
+import UIKit
+import MapKit
+
+final class SearchResultCell: UITableViewCell {
+
+    // MARK: - UI Components
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = Theme.Colors.primary
+        imageView.image = UIImage(systemName: "mappin.circle.fill")
+        return imageView
+    }()
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Theme.Fonts.headline
+        label.textColor = Theme.Colors.label
+        return label
+    }()
+
+    private let addressLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Theme.Fonts.subheadline
+        label.textColor = Theme.Colors.secondaryLabel
+        label.numberOfLines = 2
+        return label
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        contentView.addSubview(iconImageView)
+        contentView.addSubview(nameLabel)
+        contentView.addSubview(addressLabel)
+
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Theme.Spacing.lg),
+            iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 28),
+            iconImageView.heightAnchor.constraint(equalToConstant: 28),
+
+            nameLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Theme.Spacing.md),
+            nameLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: Theme.Spacing.md),
+            nameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Theme.Spacing.lg),
+
+            addressLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: Theme.Spacing.xs),
+            addressLabel.leadingAnchor.constraint(equalTo: nameLabel.leadingAnchor),
+            addressLabel.trailingAnchor.constraint(equalTo: nameLabel.trailingAnchor),
+            addressLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Theme.Spacing.md),
+        ])
+    }
+
+    // MARK: - Configure
+
+    func configure(with mapItem: MKMapItem, isHighlighted: Bool) {
+        nameLabel.text = mapItem.name
+        addressLabel.text = mapItem.address?.shortAddress ?? mapItem.address?.fullAddress
+        backgroundColor = isHighlighted ? Theme.Colors.secondaryBackground : Theme.Colors.background
+        iconImageView.tintColor = isHighlighted ? Theme.Colors.primary : Theme.Colors.secondaryLabel
+    }
+}

--- a/Navigation/Navigation/Feature/Search/SearchResultDrawerViewController.swift
+++ b/Navigation/Navigation/Feature/Search/SearchResultDrawerViewController.swift
@@ -1,0 +1,133 @@
+import UIKit
+import MapKit
+
+final class SearchResultDrawerViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let handleBar: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = Theme.Colors.separator
+        view.layer.cornerRadius = 2
+        return view
+    }()
+
+    private let tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = Theme.Colors.background
+        tableView.separatorStyle = .singleLine
+        return tableView
+    }()
+
+    // MARK: - Properties
+
+    private var searchResults: [MKMapItem] = []
+    private var highlightedIndex: Int = 0
+    private let focusTracker = DrawerListFocusTracker()
+
+    var onItemSelected: ((MKMapItem, Int) -> Void)?
+    var onFocusedIndexChanged: ((Int) -> Void)?
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupTableView()
+        setupFocusTracker()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.backgroundColor = Theme.Colors.background
+
+        view.addSubview(handleBar)
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            handleBar.topAnchor.constraint(equalTo: view.topAnchor, constant: Theme.Spacing.sm),
+            handleBar.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            handleBar.widthAnchor.constraint(equalToConstant: 36),
+            handleBar.heightAnchor.constraint(equalToConstant: 4),
+
+            tableView.topAnchor.constraint(equalTo: handleBar.bottomAnchor, constant: Theme.Spacing.sm),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(SearchResultCell.self, forCellReuseIdentifier: "SearchResultCell")
+    }
+
+    private func setupFocusTracker() {
+        focusTracker.onIndexChanged = { [weak self] index in
+            self?.onFocusedIndexChanged?(index)
+        }
+    }
+
+    // MARK: - Public Methods
+
+    func updateResults(_ results: [MKMapItem]) {
+        searchResults = results
+        highlightedIndex = 0
+        focusTracker.reset()
+        tableView.reloadData()
+    }
+
+    func scrollToIndex(_ index: Int, animated: Bool = true) {
+        guard index < searchResults.count else { return }
+        highlightedIndex = index
+        tableView.reloadData()
+        let indexPath = IndexPath(row: index, section: 0)
+        tableView.scrollToRow(at: indexPath, at: .top, animated: animated)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SearchResultDrawerViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        searchResults.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(
+            withIdentifier: "SearchResultCell",
+            for: indexPath
+        ) as? SearchResultCell else {
+            return UITableViewCell()
+        }
+
+        let item = searchResults[indexPath.row]
+        let isHighlighted = indexPath.row == highlightedIndex
+        cell.configure(with: item, isHighlighted: isHighlighted)
+        return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SearchResultDrawerViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let item = searchResults[indexPath.row]
+        onItemSelected?(item, indexPath.row)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard let indexPaths = tableView.indexPathsForVisibleRows,
+              let topIndexPath = indexPaths.first else {
+            return
+        }
+        focusTracker.notifyScroll(toIndex: topIndexPath.row)
+    }
+}

--- a/Navigation/Navigation/Feature/Search/SearchViewController.swift
+++ b/Navigation/Navigation/Feature/Search/SearchViewController.swift
@@ -1,0 +1,223 @@
+import UIKit
+import Combine
+import MapKit
+
+final class SearchViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let searchBar: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = Theme.Colors.secondaryBackground
+        view.layer.cornerRadius = Theme.CornerRadius.medium
+        return view
+    }()
+
+    private let backButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        button.tintColor = Theme.Colors.label
+        return button
+    }()
+
+    private let searchTextField: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.placeholder = "장소 또는 주소 검색"
+        textField.font = Theme.Fonts.body
+        textField.borderStyle = .none
+        textField.returnKeyType = .search
+        textField.clearButtonMode = .whileEditing
+        textField.autocorrectionType = .no
+        return textField
+    }()
+
+    private let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .grouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = Theme.Colors.background
+        tableView.keyboardDismissMode = .onDrag
+        return tableView
+    }()
+
+    // MARK: - Properties
+
+    private let viewModel: SearchViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    var onSearchResults: (([MKMapItem]) -> Void)?
+    var onDismiss: (() -> Void)?
+
+    // MARK: - Init
+
+    init(viewModel: SearchViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupTableView()
+        setupActions()
+        bindViewModel()
+        searchTextField.becomeFirstResponder()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        view.backgroundColor = Theme.Colors.background
+
+        view.addSubview(searchBar)
+        searchBar.addSubview(backButton)
+        searchBar.addSubview(searchTextField)
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Theme.Spacing.sm),
+            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Theme.Spacing.lg),
+            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Theme.Spacing.lg),
+            searchBar.heightAnchor.constraint(equalToConstant: 48),
+
+            backButton.leadingAnchor.constraint(equalTo: searchBar.leadingAnchor, constant: Theme.Spacing.sm),
+            backButton.centerYAnchor.constraint(equalTo: searchBar.centerYAnchor),
+            backButton.widthAnchor.constraint(equalToConstant: 32),
+            backButton.heightAnchor.constraint(equalToConstant: 32),
+
+            searchTextField.leadingAnchor.constraint(equalTo: backButton.trailingAnchor, constant: Theme.Spacing.sm),
+            searchTextField.trailingAnchor.constraint(equalTo: searchBar.trailingAnchor, constant: -Theme.Spacing.md),
+            searchTextField.centerYAnchor.constraint(equalTo: searchBar.centerYAnchor),
+
+            tableView.topAnchor.constraint(equalTo: searchBar.bottomAnchor, constant: Theme.Spacing.md),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+    }
+
+    private func setupTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "CompletionCell")
+    }
+
+    private func setupActions() {
+        backButton.addTarget(self, action: #selector(backTapped), for: .touchUpInside)
+        searchTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        searchTextField.delegate = self
+    }
+
+    // MARK: - Binding
+
+    private func bindViewModel() {
+        viewModel.completions
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+
+        viewModel.errorMessage
+            .compactMap { $0 }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] message in
+                self?.showError(message)
+            }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Actions
+
+    @objc private func backTapped() {
+        viewModel.clearSearch()
+        onDismiss?()
+        dismiss(animated: true)
+    }
+
+    @objc private func textFieldDidChange() {
+        guard let text = searchTextField.text else { return }
+        viewModel.updateQuery(text)
+    }
+
+    private func handleSearchResults(_ results: [MKMapItem]) {
+        guard !results.isEmpty else { return }
+        onSearchResults?(results)
+        dismiss(animated: true)
+    }
+
+    private func showError(_ message: String) {
+        let alert = UIAlertController(title: "오류", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SearchViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        viewModel.completions.value.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "CompletionCell", for: indexPath)
+        let completion = viewModel.completions.value[indexPath.row]
+
+        var config = cell.defaultContentConfiguration()
+        config.text = completion.title
+        config.secondaryText = completion.subtitle
+        config.image = UIImage(systemName: "magnifyingglass")
+        config.imageProperties.tintColor = Theme.Colors.secondaryLabel
+        cell.contentConfiguration = config
+
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        viewModel.completions.value.isEmpty ? nil : "검색 결과"
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SearchViewController: UITableViewDelegate {
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let completion = viewModel.completions.value[indexPath.row]
+
+        Task {
+            if let results = await viewModel.selectCompletion(completion) {
+                handleSearchResults(results)
+            }
+        }
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension SearchViewController: UITextFieldDelegate {
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        guard let query = textField.text, !query.isEmpty else { return false }
+
+        Task {
+            if let results = await viewModel.executeSearch(query: query) {
+                handleSearchResults(results)
+            }
+        }
+
+        textField.resignFirstResponder()
+        return true
+    }
+}

--- a/Navigation/Navigation/Feature/Search/SearchViewModel.swift
+++ b/Navigation/Navigation/Feature/Search/SearchViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Combine
+import MapKit
+
+final class SearchViewModel {
+
+    // MARK: - Publishers
+
+    let completions: CurrentValueSubject<[MKLocalSearchCompletion], Never>
+    let isLoading: CurrentValueSubject<Bool, Never>
+    let errorMessage = CurrentValueSubject<String?, Never>(nil)
+
+    // MARK: - Private
+
+    private let searchService: SearchService
+    private var cancellables = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(searchService: SearchService) {
+        self.searchService = searchService
+        self.completions = searchService.completionsPublisher
+        self.isLoading = searchService.isSearchingPublisher
+    }
+
+    // MARK: - Actions
+
+    func updateSearchRegion(_ region: MKCoordinateRegion) {
+        searchService.updateRegion(region)
+    }
+
+    func updateQuery(_ query: String) {
+        searchService.updateQuery(query)
+    }
+
+    func selectCompletion(_ completion: MKLocalSearchCompletion) async -> [MKMapItem]? {
+        do {
+            return try await searchService.search(for: completion)
+        } catch {
+            errorMessage.send("검색 실패: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func executeSearch(query: String) async -> [MKMapItem]? {
+        guard !query.isEmpty else { return nil }
+        do {
+            return try await searchService.search(query: query)
+        } catch {
+            errorMessage.send("검색 실패: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func clearSearch() {
+        searchService.updateQuery("")
+        errorMessage.send(nil)
+    }
+}

--- a/Navigation/Navigation/Map/Annotation/DestinationAnnotation.swift
+++ b/Navigation/Navigation/Map/Annotation/DestinationAnnotation.swift
@@ -1,0 +1,16 @@
+import MapKit
+
+final class DestinationAnnotation: NSObject, MKAnnotation {
+
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+
+    var title: String?
+    var subtitle: String?
+
+    init(coordinate: CLLocationCoordinate2D, title: String?, subtitle: String?) {
+        self.coordinate = coordinate
+        self.title = title
+        self.subtitle = subtitle
+        super.init()
+    }
+}

--- a/Navigation/Navigation/Map/Annotation/SearchResultAnnotation.swift
+++ b/Navigation/Navigation/Map/Annotation/SearchResultAnnotation.swift
@@ -1,0 +1,23 @@
+import MapKit
+
+final class SearchResultAnnotation: NSObject, MKAnnotation {
+
+    let mapItem: MKMapItem
+    var isFocused: Bool = false
+
+    @objc dynamic var coordinate: CLLocationCoordinate2D
+
+    var title: String? {
+        mapItem.name
+    }
+
+    var subtitle: String? {
+        mapItem.placemark.title
+    }
+
+    init(mapItem: MKMapItem) {
+        self.mapItem = mapItem
+        self.coordinate = mapItem.placemark.coordinate
+        super.init()
+    }
+}

--- a/Navigation/Navigation/Map/MapViewController.swift
+++ b/Navigation/Navigation/Map/MapViewController.swift
@@ -11,6 +11,16 @@ final class MapViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     private var hasMovedToInitialLocation = false
 
+    // MARK: - Search & Route State
+
+    private var searchResultAnnotations: [SearchResultAnnotation] = []
+    private var destinationAnnotation: DestinationAnnotation?
+    private var routeOverlays: [MKPolyline] = []
+    private var routeIsPrimary: [MKPolyline: Bool] = [:]
+
+    /// Callback when a search result marker is tapped. Returns the index.
+    var onAnnotationSelected: ((Int) -> Void)?
+
     // MARK: - Init
 
     init(locationService: LocationService) {
@@ -78,7 +88,7 @@ final class MapViewController: UIViewController {
         mapView.setRegion(region, animated: false)
     }
 
-    // MARK: - Public
+    // MARK: - Public: General
 
     func moveToLocation(_ coordinate: CLLocationCoordinate2D, animated: Bool = true) {
         let region = MKCoordinateRegion(
@@ -88,10 +98,167 @@ final class MapViewController: UIViewController {
         )
         mapView.setRegion(region, animated: animated)
     }
+
+    // MARK: - Public: Search Results
+
+    func showSearchResults(_ mapItems: [MKMapItem]) {
+        clearSearchResults()
+
+        let annotations = mapItems.map { SearchResultAnnotation(mapItem: $0) }
+        searchResultAnnotations = annotations
+        mapView.addAnnotations(annotations)
+
+        if let first = annotations.first {
+            first.isFocused = true
+            fitAnnotations(annotations)
+        }
+    }
+
+    func clearSearchResults() {
+        mapView.removeAnnotations(searchResultAnnotations)
+        searchResultAnnotations = []
+    }
+
+    func focusAnnotation(at index: Int) {
+        guard index < searchResultAnnotations.count else { return }
+
+        for annotation in searchResultAnnotations {
+            annotation.isFocused = false
+        }
+
+        let selected = searchResultAnnotations[index]
+        selected.isFocused = true
+
+        for annotation in searchResultAnnotations {
+            if let view = mapView.view(for: annotation) as? MKMarkerAnnotationView {
+                view.markerTintColor = annotation.isFocused ? Theme.Colors.primary : .systemGray
+            }
+        }
+
+        mapView.selectAnnotation(selected, animated: true)
+
+        let region = MKCoordinateRegion(
+            center: selected.coordinate,
+            latitudinalMeters: 500,
+            longitudinalMeters: 500
+        )
+        mapView.setRegion(region, animated: true)
+    }
+
+    // MARK: - Public: Destination
+
+    func showDestination(coordinate: CLLocationCoordinate2D, title: String?, subtitle: String?) {
+        clearDestination()
+        let annotation = DestinationAnnotation(coordinate: coordinate, title: title, subtitle: subtitle)
+        destinationAnnotation = annotation
+        mapView.addAnnotation(annotation)
+    }
+
+    func clearDestination() {
+        if let annotation = destinationAnnotation {
+            mapView.removeAnnotation(annotation)
+        }
+        destinationAnnotation = nil
+    }
+
+    // MARK: - Public: Routes
+
+    func showRoutes(_ routes: [MKRoute], selectedIndex: Int = 0) {
+        clearRoutes()
+
+        for (index, route) in routes.enumerated().reversed() {
+            let isPrimary = (index == selectedIndex)
+            routeOverlays.append(route.polyline)
+            routeIsPrimary[route.polyline] = isPrimary
+            mapView.addOverlay(route.polyline, level: .aboveRoads)
+        }
+
+        if selectedIndex < routes.count {
+            fitPolyline(routes[selectedIndex].polyline)
+        }
+    }
+
+    func clearRoutes() {
+        for overlay in routeOverlays {
+            mapView.removeOverlay(overlay)
+        }
+        routeOverlays = []
+        routeIsPrimary = [:]
+    }
+
+    func clearAll() {
+        clearSearchResults()
+        clearDestination()
+        clearRoutes()
+    }
+
+    // MARK: - Private Helpers
+
+    private func fitAnnotations(_ annotations: [MKAnnotation]) {
+        var rect = MKMapRect.null
+        for annotation in annotations {
+            let point = MKMapPoint(annotation.coordinate)
+            let pointRect = MKMapRect(x: point.x, y: point.y, width: 0.1, height: 0.1)
+            rect = rect.union(pointRect)
+        }
+
+        let padding = UIEdgeInsets(top: 80, left: 40, bottom: 80, right: 40)
+        mapView.setVisibleMapRect(rect, edgePadding: padding, animated: true)
+    }
+
+    private func fitPolyline(_ polyline: MKPolyline) {
+        let padding = UIEdgeInsets(top: 80, left: 40, bottom: 200, right: 40)
+        mapView.setVisibleMapRect(polyline.boundingMapRect, edgePadding: padding, animated: true)
+    }
 }
 
 // MARK: - MKMapViewDelegate
 
 extension MapViewController: MKMapViewDelegate {
 
+    func mapView(_ mapView: MKMapView, viewFor annotation: any MKAnnotation) -> MKAnnotationView? {
+        if annotation is MKUserLocation { return nil }
+
+        if let searchResult = annotation as? SearchResultAnnotation {
+            let identifier = "SearchResult"
+            let view = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? MKMarkerAnnotationView
+                ?? MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+            view.annotation = annotation
+            view.markerTintColor = searchResult.isFocused ? Theme.Colors.primary : .systemGray
+            view.glyphImage = UIImage(systemName: "mappin")
+            view.animatesWhenAdded = true
+            view.canShowCallout = true
+            return view
+        }
+
+        if annotation is DestinationAnnotation {
+            let identifier = "Destination"
+            let view = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? MKMarkerAnnotationView
+                ?? MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+            view.annotation = annotation
+            view.markerTintColor = .systemRed
+            view.glyphImage = UIImage(systemName: "flag.fill")
+            view.animatesWhenAdded = true
+            view.canShowCallout = true
+            return view
+        }
+
+        return nil
+    }
+
+    func mapView(_ mapView: MKMapView, rendererFor overlay: any MKOverlay) -> MKOverlayRenderer {
+        if let polyline = overlay as? MKPolyline {
+            let isPrimary = routeIsPrimary[polyline] ?? false
+            return RouteOverlayRenderer(polyline: polyline, isPrimary: isPrimary)
+        }
+        return MKOverlayRenderer(overlay: overlay)
+    }
+
+    func mapView(_ mapView: MKMapView, didSelect annotation: any MKAnnotation) {
+        guard let searchAnnotation = annotation as? SearchResultAnnotation,
+              let index = searchResultAnnotations.firstIndex(where: { $0 === searchAnnotation }) else {
+            return
+        }
+        onAnnotationSelected?(index)
+    }
 }

--- a/Navigation/Navigation/Map/Overlay/RouteOverlayRenderer.swift
+++ b/Navigation/Navigation/Map/Overlay/RouteOverlayRenderer.swift
@@ -1,0 +1,13 @@
+import MapKit
+import UIKit
+
+final class RouteOverlayRenderer: MKPolylineRenderer {
+
+    init(polyline: MKPolyline, isPrimary: Bool) {
+        super.init(polyline: polyline)
+        strokeColor = isPrimary ? Theme.Colors.primary : Theme.Colors.secondaryLabel.withAlphaComponent(0.5)
+        lineWidth = isPrimary ? 5.0 : 3.0
+        lineCap = .round
+        lineJoin = .round
+    }
+}

--- a/Navigation/Navigation/Model/FavoritePlace.swift
+++ b/Navigation/Navigation/Model/FavoritePlace.swift
@@ -1,0 +1,37 @@
+import SwiftData
+import CoreLocation
+
+@Model
+final class FavoritePlace {
+    var id: UUID
+    var name: String
+    var address: String
+    var latitude: Double
+    var longitude: Double
+    var category: String
+    var sortOrder: Int
+    var createdAt: Date
+    var lastUsedAt: Date
+
+    init(
+        name: String,
+        address: String,
+        latitude: Double,
+        longitude: Double,
+        category: String = "custom"
+    ) {
+        self.id = UUID()
+        self.name = name
+        self.address = address
+        self.latitude = latitude
+        self.longitude = longitude
+        self.category = category
+        self.sortOrder = 0
+        self.createdAt = Date()
+        self.lastUsedAt = Date()
+    }
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}

--- a/Navigation/Navigation/Model/SearchHistory.swift
+++ b/Navigation/Navigation/Model/SearchHistory.swift
@@ -1,0 +1,33 @@
+import SwiftData
+import CoreLocation
+
+@Model
+final class SearchHistory {
+    var id: UUID
+    var query: String
+    var placeName: String
+    var address: String
+    var latitude: Double
+    var longitude: Double
+    var searchedAt: Date
+
+    init(
+        query: String,
+        placeName: String,
+        address: String,
+        latitude: Double,
+        longitude: Double
+    ) {
+        self.id = UUID()
+        self.query = query
+        self.placeName = placeName
+        self.address = address
+        self.latitude = latitude
+        self.longitude = longitude
+        self.searchedAt = Date()
+    }
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}

--- a/Navigation/Navigation/Service/Route/RouteModels.swift
+++ b/Navigation/Navigation/Service/Route/RouteModels.swift
@@ -1,0 +1,68 @@
+import MapKit
+
+// MARK: - Transport Mode
+
+enum TransportMode: String, Sendable {
+    case automobile
+    case walking
+
+    var mkTransportType: MKDirectionsTransportType {
+        switch self {
+        case .automobile: return .automobile
+        case .walking: return .walking
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .automobile: return "자동차"
+        case .walking: return "도보"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .automobile: return "car.fill"
+        case .walking: return "figure.walk"
+        }
+    }
+}
+
+// MARK: - MKRoute Extension
+
+extension MKRoute {
+
+    var formattedDistance: String {
+        let km = distance / 1000.0
+        if km < 1 {
+            return String(format: "%dm", Int(distance))
+        } else {
+            return String(format: "%.1fkm", km)
+        }
+    }
+
+    var formattedTravelTime: String {
+        let totalMinutes = Int(expectedTravelTime / 60)
+        if totalMinutes < 60 {
+            return "\(totalMinutes)분"
+        } else {
+            let hours = totalMinutes / 60
+            let minutes = totalMinutes % 60
+            if minutes == 0 {
+                return "\(hours)시간"
+            }
+            return "\(hours)시간 \(minutes)분"
+        }
+    }
+
+    var estimatedArrivalTime: Date {
+        Date().addingTimeInterval(expectedTravelTime)
+    }
+
+    var formattedArrivalTime: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        formatter.locale = Locale(identifier: "ko_KR")
+        return formatter.string(from: estimatedArrivalTime) + " 도착"
+    }
+}

--- a/Navigation/Navigation/Service/Route/RouteService.swift
+++ b/Navigation/Navigation/Service/Route/RouteService.swift
@@ -1,0 +1,93 @@
+import MapKit
+import CoreLocation
+
+final class RouteService {
+
+    // MARK: - Private
+
+    private var currentDirections: MKDirections?
+    private let maxRetryCount = 3
+
+    // MARK: - Public Methods
+
+    func calculateRoutes(
+        from origin: CLLocationCoordinate2D,
+        to destination: CLLocationCoordinate2D,
+        transportType: MKDirectionsTransportType = .automobile
+    ) async throws -> [MKRoute] {
+        cancelCurrentRequest()
+
+        let request = MKDirections.Request()
+        request.source = MKMapItem(location: CLLocation(latitude: origin.latitude, longitude: origin.longitude), address: nil)
+        request.destination = MKMapItem(location: CLLocation(latitude: destination.latitude, longitude: destination.longitude), address: nil)
+        request.transportType = transportType
+        request.requestsAlternateRoutes = true
+
+        return try await performWithRetry(request: request)
+    }
+
+    func calculateETA(
+        from origin: CLLocationCoordinate2D,
+        to destination: CLLocationCoordinate2D
+    ) async throws -> MKDirections.ETAResponse {
+        let request = MKDirections.Request()
+        request.source = MKMapItem(location: CLLocation(latitude: origin.latitude, longitude: origin.longitude), address: nil)
+        request.destination = MKMapItem(location: CLLocation(latitude: destination.latitude, longitude: destination.longitude), address: nil)
+        request.transportType = .automobile
+
+        let directions = MKDirections(request: request)
+        return try await directions.calculateETA()
+    }
+
+    func cancelCurrentRequest() {
+        currentDirections?.cancel()
+        currentDirections = nil
+    }
+
+    // MARK: - Private
+
+    private func performWithRetry(
+        request: MKDirections.Request,
+        attempt: Int = 0
+    ) async throws -> [MKRoute] {
+        let directions = MKDirections(request: request)
+        currentDirections = directions
+
+        do {
+            let response = try await directions.calculate()
+            guard !response.routes.isEmpty else {
+                throw RouteServiceError.noRoutesFound
+            }
+            return response.routes
+        } catch let error as RouteServiceError {
+            throw error
+        } catch {
+            if attempt < maxRetryCount - 1 {
+                // Exponential backoff: 1s, 2s, 4s
+                let delay = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
+                try await Task.sleep(nanoseconds: delay)
+                return try await performWithRetry(request: request, attempt: attempt + 1)
+            }
+            throw RouteServiceError.networkError(error)
+        }
+    }
+}
+
+// MARK: - Error
+
+enum RouteServiceError: Error, LocalizedError {
+    case noRoutesFound
+    case networkError(Error)
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .noRoutesFound:
+            return "경로를 찾을 수 없습니다"
+        case .networkError(let error):
+            return "네트워크 오류: \(error.localizedDescription)"
+        case .cancelled:
+            return "경로 탐색이 취소되었습니다"
+        }
+    }
+}

--- a/Navigation/Navigation/Service/Search/GeocodingService.swift
+++ b/Navigation/Navigation/Service/Search/GeocodingService.swift
@@ -1,0 +1,51 @@
+import MapKit
+import CoreLocation
+
+final class GeocodingService {
+
+    // MARK: - Public Methods
+
+    func reverseGeocode(location: CLLocation) async throws -> MKMapItem {
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = nil
+        request.region = MKCoordinateRegion(
+            center: location.coordinate,
+            latitudinalMeters: 100,
+            longitudinalMeters: 100
+        )
+
+        let search = MKLocalSearch(request: request)
+        let response = try await search.start()
+
+        guard let item = response.mapItems.first else {
+            throw GeocodingError.noResults
+        }
+        return item
+    }
+
+    func geocode(address: String) async throws -> MKMapItem {
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = address
+
+        let search = MKLocalSearch(request: request)
+        let response = try await search.start()
+
+        guard let item = response.mapItems.first else {
+            throw GeocodingError.noResults
+        }
+        return item
+    }
+}
+
+// MARK: - Error
+
+enum GeocodingError: Error, LocalizedError {
+    case noResults
+
+    var errorDescription: String? {
+        switch self {
+        case .noResults:
+            return "주소를 찾을 수 없습니다"
+        }
+    }
+}

--- a/Navigation/Navigation/Service/Search/SearchService.swift
+++ b/Navigation/Navigation/Service/Search/SearchService.swift
@@ -1,0 +1,103 @@
+import MapKit
+import Combine
+
+final class SearchService: NSObject {
+
+    // MARK: - Publishers
+
+    let completionsPublisher = CurrentValueSubject<[MKLocalSearchCompletion], Never>([])
+    let isSearchingPublisher = CurrentValueSubject<Bool, Never>(false)
+
+    // MARK: - Private
+
+    private let completer = MKLocalSearchCompleter()
+    private var currentSearch: MKLocalSearch?
+
+    // MARK: - Init
+
+    override init() {
+        super.init()
+        completer.delegate = self
+        completer.resultTypes = [.pointOfInterest, .address, .query]
+    }
+
+    // MARK: - Public Methods
+
+    func updateRegion(_ region: MKCoordinateRegion) {
+        completer.region = region
+    }
+
+    func updateQuery(_ fragment: String) {
+        if fragment.isEmpty {
+            completionsPublisher.send([])
+            completer.queryFragment = ""
+        } else {
+            completer.queryFragment = fragment
+        }
+    }
+
+    func search(for completion: MKLocalSearchCompletion) async throws -> [MKMapItem] {
+        cancelCurrentSearch()
+        isSearchingPublisher.send(true)
+
+        let request = MKLocalSearch.Request(completion: completion)
+        request.region = completer.region
+
+        let search = MKLocalSearch(request: request)
+        currentSearch = search
+
+        do {
+            let response = try await search.start()
+            isSearchingPublisher.send(false)
+            return response.mapItems
+        } catch {
+            isSearchingPublisher.send(false)
+            throw error
+        }
+    }
+
+    func search(query: String, region: MKCoordinateRegion? = nil) async throws -> [MKMapItem] {
+        cancelCurrentSearch()
+        isSearchingPublisher.send(true)
+
+        let request = MKLocalSearch.Request()
+        request.naturalLanguageQuery = query
+        if let region {
+            request.region = region
+        } else {
+            request.region = completer.region
+        }
+
+        let search = MKLocalSearch(request: request)
+        currentSearch = search
+
+        do {
+            let response = try await search.start()
+            isSearchingPublisher.send(false)
+            return response.mapItems
+        } catch {
+            isSearchingPublisher.send(false)
+            throw error
+        }
+    }
+
+    func cancelCurrentSearch() {
+        currentSearch?.cancel()
+        currentSearch = nil
+    }
+}
+
+// MARK: - MKLocalSearchCompleterDelegate
+
+extension SearchService: MKLocalSearchCompleterDelegate {
+
+    nonisolated func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+        MainActor.assumeIsolated {
+            completionsPublisher.send(completer.results)
+        }
+    }
+
+    nonisolated func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
+        print("[SearchService] Completer error: \(error.localizedDescription)")
+    }
+}


### PR DESCRIPTION
## Sprint 2: 검색 + 경로 탐색 기능 구현

### Summary
- 장소 검색 → 결과 드로어 + 지도 마커 양방향 동기화 → 경로 미리보기 전체 플로우 구현
- iOS 26 신규 API 대응 (`MKAddress`, `MKMapItem(location:address:)`)
- MVVM + Coordinator 패턴 유지, Combine 기반 반응형 바인딩

### 주요 변경사항

**서비스 레이어 (4개)**
- `SearchService` — MKLocalSearchCompleter + MKLocalSearch 래핑, 자동완성/검색 퍼블리셔
- `GeocodingService` — MKLocalSearch 기반 지오코딩 (iOS 26 대응, CLGeocoder 미사용)
- `RouteService` — MKDirections 래핑, 3회 exponential backoff 재시도
- `RouteModels` — TransportMode enum, MKRoute 포매팅 extension

**데이터 모델 (2개)**
- `FavoritePlace` — SwiftData @Model, 즐겨찾기 장소 (Sprint 4 대비)
- `SearchHistory` — SwiftData @Model, 검색 기록 (Sprint 4 대비)

**지도 컴포넌트 (3개)**
- `SearchResultAnnotation` — 검색 결과 마커, isFocused 상태로 드로어 동기화
- `DestinationAnnotation` — 목적지 핀 마커
- `RouteOverlayRenderer` — 경로 폴리라인 렌더러 (primary/alternative 구분)

**검색 기능 (5개)**
- `SearchViewModel` — SearchService 래핑, 자동완성/검색 액션
- `SearchViewController` — 전체화면 검색 UI (텍스트 입력 + 자동완성 테이블)
- `SearchResultCell` — 검색 결과 셀 (아이콘 + 이름 + 주소)
- `SearchResultDrawerViewController` — UISheetPresentationController 기반 bottom sheet
- `DrawerListFocusTracker` — 스크롤 debounce (0.15s) 포커스 추적

**경로 미리보기 (3개)**
- `RoutePreviewViewModel` — 경로 계산/선택 상태 관리
- `RoutePreviewViewController` — 지도 + 경로 옵션 리스트 + 안내 시작 버튼
- `RouteOptionCell` — 경로 옵션 셀 (시간 + 거리 + 도착 예정)

**기존 파일 수정 (3개)**
- `MapViewController` — 검색 마커, 목적지 핀, 경로 폴리라인 표시/제거 메서드 추가
- `HomeViewController` — 검색바 탭 콜백 (`onSearchBarTapped`) 추가
- `AppCoordinator` — 전체 플로우 연결 (검색 → 드로어 → 경로 미리보기 → 안내 시작 stub)

### 전체 플로우
홈(검색바 탭) → 검색화면(자동완성) → 결과 드로어 + 지도 마커(양방향 동기화) → 항목 선택 → 경로 미리보기(폴리라인 + 옵션) → "안내 시작" (Sprint 3)


### Test plan
- [ ] 검색바 탭 → 검색 화면 열림 (키보드 자동 활성)
- [ ] 텍스트 입력 → 자동완성 결과 실시간 표시
- [ ] 자동완성 항목 탭 → 지도 마커 + 드로어 표시
- [ ] 드로어 스크롤 ↔ 지도 마커 포커스 양방향 동기화
- [ ] 드로어 항목 탭 → 경로 미리보기 (폴리라인 + 경로 옵션)
- [ ] 경로 선택 변경 시 지도 폴리라인 업데이트
- [ ] "안내 시작" 버튼 탭 시 콘솔 로그 출력
- [ ] 빌드 성공, 경고 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)
