### PR TITLE
feat(lbs): LBS provider 검색/경로 독립 분리 및 한도 초과 팝업

### DIFF
--- a/Navigation/Navigation/Coordinator/AppCoordinator.swift
+++ b/Navigation/Navigation/Coordinator/AppCoordinator.swift
@@ -469,6 +469,7 @@ final class AppCoordinator: NSObject, Coordinator {
 
     private func searchCategory(_ category: SearchCategory) {
         let region = mapViewController.mapView.region
+        let provider = LBSServiceProvider.shared.searchProviderType.rawValue
 
         Task {
             do {
@@ -479,7 +480,6 @@ final class AppCoordinator: NSObject, Coordinator {
                 )
                 showSearchResults(results, query: category.name)
             } catch {
-                print("[AppCoordinator] Category search failed: \(error.localizedDescription)")
             }
         }
     }
@@ -620,6 +620,7 @@ final class AppCoordinator: NSObject, Coordinator {
         let query = lastSearchQuery
         guard !query.isEmpty else { return }
         let region = mapViewController.mapView.region
+        let provider = LBSServiceProvider.shared.searchProviderType.rawValue
 
         Task {
             do {
@@ -632,7 +633,6 @@ final class AppCoordinator: NSObject, Coordinator {
                 mapViewController.showSearchResults(results)
                 currentDrawer?.updateResults(results)
             } catch {
-                print("[AppCoordinator] Research failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Navigation/Navigation/Feature/DevTools/DevToolsViewController.swift
+++ b/Navigation/Navigation/Feature/DevTools/DevToolsViewController.swift
@@ -10,6 +10,12 @@ final class DevToolsViewController: UIViewController {
         case recording = 1
         case files = 2
         case debug = 3
+        case lbsProvider = 4
+    }
+
+    private enum LBSProviderRow: Int, CaseIterable {
+        case searchProvider = 0
+        case routeProvider = 1
     }
 
     private enum GPSRow: Int, CaseIterable {
@@ -140,6 +146,13 @@ final class DevToolsViewController: UIViewController {
             }
             .store(in: &cancellables)
 
+        Publishers.CombineLatest(viewModel.searchProvider, viewModel.routeProvider)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _, _ in
+                self?.tableView.reloadSections(IndexSet(integer: Section.lbsProvider.rawValue), with: .none)
+            }
+            .store(in: &cancellables)
+
         Publishers.CombineLatest(
             viewModel.locationType,
             viewModel.selectedRecordingFileName
@@ -227,6 +240,7 @@ extension DevToolsViewController: UITableViewDataSource {
         case .recording: return RecordingRow.allCases.count
         case .files: return FilesRow.allCases.count
         case .debug: return DebugRow.allCases.count
+        case .lbsProvider: return LBSProviderRow.allCases.count
         }
     }
 
@@ -237,6 +251,7 @@ extension DevToolsViewController: UITableViewDataSource {
         case .recording: return "녹화"
         case .files: return "파일 관리"
         case .debug: return "디버그"
+        case .lbsProvider: return "위치 서비스"
         }
     }
 
@@ -341,6 +356,23 @@ extension DevToolsViewController: UITableViewDataSource {
                 cell.accessoryType = .disclosureIndicator
             }
 
+        case .lbsProvider:
+            guard let row = LBSProviderRow(rawValue: indexPath.row) else { return cell }
+            switch row {
+            case .searchProvider:
+                config.text = "검색 제공자"
+                config.secondaryText = viewModel.searchProvider.value.displayName
+                config.image = UIImage(systemName: "magnifyingglass")
+                config.imageProperties.tintColor = Theme.Colors.primary
+                cell.accessoryType = .disclosureIndicator
+            case .routeProvider:
+                config.text = "경로 제공자"
+                config.secondaryText = viewModel.routeProvider.value.displayName
+                config.image = UIImage(systemName: "car.fill")
+                config.imageProperties.tintColor = Theme.Colors.primary
+                cell.accessoryType = .disclosureIndicator
+            }
+
         case .debug:
             guard let row = DebugRow(rawValue: indexPath.row) else { return cell }
             switch row {
@@ -423,6 +455,48 @@ extension DevToolsViewController: UITableViewDelegate {
 
         case .debug:
             break
+
+        case .lbsProvider:
+            guard let row = LBSProviderRow(rawValue: indexPath.row) else { return }
+            switch row {
+            case .searchProvider: showSearchProviderPicker()
+            case .routeProvider: showRouteProviderPicker()
+            }
         }
+    }
+}
+
+// MARK: - LBS Provider Pickers
+
+private extension DevToolsViewController {
+
+    func showSearchProviderPicker() {
+        let alert = UIAlertController(title: "검색 제공자", message: nil, preferredStyle: .actionSheet)
+        for provider in LBSProviderType.allCases {
+            let action = UIAlertAction(title: provider.displayName, style: .default) { [weak self] _ in
+                self?.viewModel.setSearchProvider(provider)
+            }
+            if provider == viewModel.searchProvider.value {
+                action.setValue(true, forKey: "checked")
+            }
+            alert.addAction(action)
+        }
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        present(alert, animated: true)
+    }
+
+    func showRouteProviderPicker() {
+        let alert = UIAlertController(title: "경로 제공자", message: nil, preferredStyle: .actionSheet)
+        for provider in LBSProviderType.allCases {
+            let action = UIAlertAction(title: provider.displayName, style: .default) { [weak self] _ in
+                self?.viewModel.setRouteProvider(provider)
+            }
+            if provider == viewModel.routeProvider.value {
+                action.setValue(true, forKey: "checked")
+            }
+            alert.addAction(action)
+        }
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        present(alert, animated: true)
     }
 }

--- a/Navigation/Navigation/Feature/DevTools/DevToolsViewModel.swift
+++ b/Navigation/Navigation/Feature/DevTools/DevToolsViewModel.swift
@@ -19,6 +19,8 @@ final class DevToolsViewModel {
     let debugOverlayEnabled = CurrentValueSubject<Bool, Never>(false)
     let locationType = CurrentValueSubject<DevToolsSettings.LocationType, Never>(.real)
     let selectedRecordingFileName = CurrentValueSubject<String?, Never>(nil)
+    let searchProvider = CurrentValueSubject<LBSProviderType, Never>(LBSServiceProvider.shared.searchProviderType)
+    let routeProvider = CurrentValueSubject<LBSProviderType, Never>(LBSServiceProvider.shared.routeProviderType)
 
     // MARK: - Dependencies
 
@@ -112,6 +114,16 @@ final class DevToolsViewModel {
             // 주행 중이면 사용자가 직접 정지할 수 있음 (옵션)
             stopAndSave()
         }
+    }
+
+    func setSearchProvider(_ type: LBSProviderType) {
+        LBSServiceProvider.shared.switchSearchProvider(to: type)
+        searchProvider.send(type)
+    }
+
+    func setRouteProvider(_ type: LBSProviderType) {
+        LBSServiceProvider.shared.switchRouteProvider(to: type)
+        routeProvider.send(type)
     }
 
     func setDebugOverlayEnabled(_ enabled: Bool) {

--- a/Navigation/Navigation/Feature/Home/HomeDrawerViewController.swift
+++ b/Navigation/Navigation/Feature/Home/HomeDrawerViewController.swift
@@ -122,6 +122,18 @@ final class HomeDrawerViewController: UIViewController {
                 self?.collectionView.reloadData()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reloadCategories),
+            name: .lbsSearchProviderChanged,
+            object: nil
+        )
+    }
+
+    @objc private func reloadCategories() {
+        let count = LBSServiceProvider.shared.search.supportedCategories.count
+        collectionView.reloadSections(IndexSet(integer: HomeSection.categories.rawValue))
     }
 
     // MARK: - Compositional Layout

--- a/Navigation/Navigation/Feature/Home/HomeViewController.swift
+++ b/Navigation/Navigation/Feature/Home/HomeViewController.swift
@@ -37,6 +37,7 @@ final class HomeViewController: UIViewController {
         setupDrawerContainer()
         bindViewModel()
         handleInitialPermission()
+        setupLBSNotifications()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -170,6 +171,49 @@ final class HomeViewController: UIViewController {
         case .notDetermined:
             break
         }
+    }
+
+    // MARK: - LBS Notifications
+
+    private func setupLBSNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSearchQuotaExceeded),
+            name: .lbsSearchQuotaExceeded,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleRouteFallback),
+            name: .lbsRouteFallbackActivated,
+            object: nil
+        )
+    }
+
+    @objc private func handleSearchQuotaExceeded() {
+        DispatchQueue.main.async { [weak self] in
+            self?.showLBSAlert(
+                title: "검색 한도 초과",
+                message: "오늘 카카오 검색 한도에 도달했습니다.\n내일 자정에 자동으로 초기화됩니다."
+            )
+        }
+    }
+
+    @objc private func handleRouteFallback() {
+        guard LBSServiceProvider.shared.routeProviderType == .kakao else { return }
+        DispatchQueue.main.async { [weak self] in
+            self?.showLBSAlert(
+                title: "경로 서비스 일시 제한",
+                message: "카카오 경로 서비스가 일시적으로 제한됩니다.\n잠시 후 자동으로 복구됩니다."
+            )
+        }
+    }
+
+    private func showLBSAlert(title: String, message: String) {
+        guard presentedViewController == nil else { return }
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
     }
 
     private func showLocationDeniedAlert() {

--- a/Navigation/Navigation/Feature/Search/SearchViewController.swift
+++ b/Navigation/Navigation/Feature/Search/SearchViewController.swift
@@ -250,6 +250,12 @@ final class SearchViewController: UIViewController {
     }
 
     private func updateQueryChips(_ completions: [SearchCompletion]) {
+        let provider = LBSServiceProvider.shared.searchProviderType.rawValue
+        if completions.isEmpty {
+        } else {
+            let titles = completions.map { $0.title }.joined(separator: ", ")
+        }
+
         queryChipStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
         let showChips = !completions.isEmpty
@@ -283,6 +289,7 @@ final class SearchViewController: UIViewController {
     }
 
     private func handleQueryChipTapped(_ completion: SearchCompletion) {
+        let provider = LBSServiceProvider.shared.searchProviderType.rawValue
         Task { [weak self] in
             guard let self else { return }
             if let results = await viewModel.selectCompletion(completion) {

--- a/Navigation/Navigation/Feature/Search/SearchViewModel.swift
+++ b/Navigation/Navigation/Feature/Search/SearchViewModel.swift
@@ -6,35 +6,27 @@ final class SearchViewModel {
 
     // MARK: - Publishers
 
-    let completions: CurrentValueSubject<[SearchCompletion], Never>
-    let queryCompletions: CurrentValueSubject<[SearchCompletion], Never>
-    let isLoading: CurrentValueSubject<Bool, Never>
-    let hasMoreResults: CurrentValueSubject<Bool, Never>
+    let completions = CurrentValueSubject<[SearchCompletion], Never>([])
+    let queryCompletions = CurrentValueSubject<[SearchCompletion], Never>([])
+    let isLoading = CurrentValueSubject<Bool, Never>(false)
+    let hasMoreResults = CurrentValueSubject<Bool, Never>(false)
     let errorMessage = CurrentValueSubject<String?, Never>(nil)
     let recentSearches = CurrentValueSubject<[SearchHistory], Never>([])
 
     // MARK: - Private
 
-    private let searchService: SearchProviding
+    private var searchService: SearchProviding
     private let dataService: DataService
     private var cancellables = Set<AnyCancellable>()
+    private var serviceCancellables = Set<AnyCancellable>()
 
     // MARK: - Init
 
     init(searchService: SearchProviding, dataService: DataService = .shared) {
         self.searchService = searchService
         self.dataService = dataService
-        self.completions = searchService.completionsPublisher
-        self.queryCompletions = searchService.queryCompletionsPublisher
-        self.isLoading = searchService.isSearchingPublisher
-        self.hasMoreResults = searchService.hasMoreResults
-
-        searchService.errorPublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] error in
-                self?.errorMessage.send("검색 오류: \(error.localizedDescription)")
-            }
-            .store(in: &cancellables)
+        bindSearchService()
+        observeProviderChange()
     }
 
     // MARK: - Actions
@@ -110,5 +102,53 @@ final class SearchViewModel {
     func clearSearch() {
         searchService.updateQuery("")
         errorMessage.send(nil)
+    }
+
+    // MARK: - Private
+
+    private func bindSearchService() {
+        serviceCancellables.removeAll()
+
+        searchService.completionsPublisher
+            .sink { [weak self] in self?.completions.send($0) }
+            .store(in: &serviceCancellables)
+
+        searchService.queryCompletionsPublisher
+            .sink { [weak self] in self?.queryCompletions.send($0) }
+            .store(in: &serviceCancellables)
+
+        searchService.isSearchingPublisher
+            .sink { [weak self] in self?.isLoading.send($0) }
+            .store(in: &serviceCancellables)
+
+        searchService.hasMoreResults
+            .sink { [weak self] in self?.hasMoreResults.send($0) }
+            .store(in: &serviceCancellables)
+
+        searchService.errorPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] error in
+                self?.errorMessage.send("검색 오류: \(error.localizedDescription)")
+            }
+            .store(in: &serviceCancellables)
+    }
+
+    private func observeProviderChange() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleProviderChanged),
+            name: .lbsSearchProviderChanged,
+            object: nil
+        )
+    }
+
+    @objc private func handleProviderChanged() {
+        DispatchQueue.main.async { [weak self] in
+            self?.searchService.cancelCurrentSearch()
+            self?.searchService = LBSServiceProvider.shared.search
+            self?.bindSearchService()
+            self?.completions.send([])
+            self?.queryCompletions.send([])
+        }
     }
 }

--- a/Navigation/Navigation/Feature/Settings/SettingsViewController.swift
+++ b/Navigation/Navigation/Feature/Settings/SettingsViewController.swift
@@ -11,16 +11,11 @@ final class SettingsViewController: UIViewController {
         case voice = 0
         case transport = 1
         case map = 2
-        case lbsProvider = 3
-        case vehicle = 4
-        case haptic = 5
-        case data = 6
-        case info = 7
-        case devTools = 8
-    }
-
-    private enum LBSProviderRow: Int, CaseIterable {
-        case provider = 0
+        case vehicle = 3
+        case haptic = 4
+        case data = 5
+        case info = 6
+        case devTools = 7
     }
 
     private enum DevToolsRow: Int, CaseIterable {
@@ -170,13 +165,6 @@ final class SettingsViewController: UIViewController {
         }
         .store(in: &cancellables)
 
-        viewModel.lbsProvider
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.tableView.reloadData()
-            }
-            .store(in: &cancellables)
-
         VehicleIconService.shared.iconSourcePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
@@ -221,23 +209,6 @@ final class SettingsViewController: UIViewController {
                 self?.viewModel.setMapType(mapType)
             }
             if mapType == viewModel.mapType.value {
-                action.setValue(true, forKey: "checked")
-            }
-            alert.addAction(action)
-        }
-
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
-        present(alert, animated: true)
-    }
-
-    private func showLBSProviderPicker() {
-        let alert = UIAlertController(title: "검색/경로 제공자", message: "Kakao 선택 시 API 키가 필요합니다.", preferredStyle: .actionSheet)
-
-        for provider in LBSProviderType.allCases {
-            let action = UIAlertAction(title: provider.displayName, style: .default) { [weak self] _ in
-                self?.viewModel.setLBSProvider(provider)
-            }
-            if provider == viewModel.lbsProvider.value {
                 action.setValue(true, forKey: "checked")
             }
             alert.addAction(action)
@@ -527,7 +498,6 @@ extension SettingsViewController: UITableViewDataSource {
         case .voice: return VoiceRow.allCases.count
         case .transport: return TransportRow.allCases.count
         case .map: return MapRow.allCases.count
-        case .lbsProvider: return LBSProviderRow.allCases.count
         case .vehicle: return VehicleRow.allCases.count
         case .haptic: return HapticRow.allCases.count
         case .data: return DataRow.allCases.count
@@ -542,7 +512,6 @@ extension SettingsViewController: UITableViewDataSource {
         case .voice: return "음성 안내"
         case .transport: return "이동수단"
         case .map: return "지도"
-        case .lbsProvider: return "위치 서비스"
         case .vehicle: return "차량 아이콘"
         case .haptic: return "햅틱"
         case .data: return "데이터"
@@ -608,17 +577,6 @@ extension SettingsViewController: UITableViewDataSource {
                 config.secondaryText = viewModel.mapType.value.displayName
                 config.image = UIImage(systemName: "map.fill")
                 config.imageProperties.tintColor = Theme.Colors.success
-                cell.accessoryType = .disclosureIndicator
-            }
-
-        case .lbsProvider:
-            guard let row = LBSProviderRow(rawValue: indexPath.row) else { return cell }
-            switch row {
-            case .provider:
-                config.text = "검색/경로 제공자"
-                config.secondaryText = viewModel.lbsProvider.value.displayName
-                config.image = UIImage(systemName: "location.magnifyingglass")
-                config.imageProperties.tintColor = Theme.Colors.primary
                 cell.accessoryType = .disclosureIndicator
             }
 
@@ -739,12 +697,6 @@ extension SettingsViewController: UITableViewDelegate {
             guard let row = MapRow(rawValue: indexPath.row) else { return }
             if row == .type {
                 showMapTypePicker()
-            }
-
-        case .lbsProvider:
-            guard let row = LBSProviderRow(rawValue: indexPath.row) else { return }
-            if row == .provider {
-                showLBSProviderPicker()
             }
 
         case .vehicle:

--- a/Navigation/Navigation/Feature/Settings/SettingsViewModel.swift
+++ b/Navigation/Navigation/Feature/Settings/SettingsViewModel.swift
@@ -73,8 +73,11 @@ final class SettingsViewModel {
     let hapticEnabled = CurrentValueSubject<Bool, Never>(true)
     let vehiclePreset = CurrentValueSubject<VehiclePreset, Never>(.sedan)
     let vehicle3DEnabled = CurrentValueSubject<Bool, Never>(false)
-    let lbsProvider = CurrentValueSubject<LBSProviderType, Never>(
-        LBSServiceProvider.shared.providerType
+    let searchProvider = CurrentValueSubject<LBSProviderType, Never>(
+        LBSServiceProvider.shared.searchProviderType
+    )
+    let routeProvider = CurrentValueSubject<LBSProviderType, Never>(
+        LBSServiceProvider.shared.routeProviderType
     )
     let favoriteCount = CurrentValueSubject<Int, Never>(0)
     let searchHistoryCount = CurrentValueSubject<Int, Never>(0)
@@ -168,9 +171,14 @@ final class SettingsViewModel {
         VehicleIconService.shared.selectPreset(preset)
     }
 
-    func setLBSProvider(_ type: LBSProviderType) {
-        LBSServiceProvider.shared.switchProvider(to: type)
-        lbsProvider.send(type)
+    func setSearchProvider(_ type: LBSProviderType) {
+        LBSServiceProvider.shared.switchSearchProvider(to: type)
+        searchProvider.send(type)
+    }
+
+    func setRouteProvider(_ type: LBSProviderType) {
+        LBSServiceProvider.shared.switchRouteProvider(to: type)
+        routeProvider.send(type)
     }
 
     func setVehicle3DEnabled(_ enabled: Bool) {

--- a/Navigation/Navigation/Service/LBS/Fallback/FallbackRouteService.swift
+++ b/Navigation/Navigation/Service/LBS/Fallback/FallbackRouteService.swift
@@ -29,24 +29,32 @@ final class FallbackRouteService: RouteProviding {
 
         if isPrimaryAvailable {
             do {
-                return try await primary.calculateRoutes(
+                let routes = try await primary.calculateRoutes(
                     from: origin, to: destination, heading: heading, transportMode: transportMode
                 )
+                logRouteResult(routes, label: "primary")
+                return routes
             } catch let error as LBSError where error == .quotaExceeded {
                 markPrimaryUnavailable()
-                return try await fallback.calculateRoutes(
+                let routes = try await fallback.calculateRoutes(
                     from: origin, to: destination, heading: heading, transportMode: transportMode
                 )
+                logRouteResult(routes, label: "fallback/quota")
+                return routes
             } catch let error as LBSError where error == .noRoutesFound {
-                return try await fallback.calculateRoutes(
+                let routes = try await fallback.calculateRoutes(
                     from: origin, to: destination, heading: heading, transportMode: transportMode
                 )
+                logRouteResult(routes, label: "fallback/noRoute")
+                return routes
             }
         }
 
-        return try await fallback.calculateRoutes(
+        let routes = try await fallback.calculateRoutes(
             from: origin, to: destination, heading: heading, transportMode: transportMode
         )
+        logRouteResult(routes, label: "fallback")
+        return routes
     }
 
     func calculateETA(
@@ -78,8 +86,11 @@ final class FallbackRouteService: RouteProviding {
         isPrimaryAvailable = false
         lastQuotaExceededDate = Date()
         NotificationCenter.default.post(
-            name: .lbsProviderFallbackActivated, object: nil
+            name: .lbsRouteFallbackActivated, object: nil
         )
+    }
+
+    private func logRouteResult(_ result: [Route], label: String) {
     }
 
     private func checkRecovery() {
@@ -90,6 +101,3 @@ final class FallbackRouteService: RouteProviding {
     }
 }
 
-extension Notification.Name {
-    static let lbsProviderFallbackActivated = Notification.Name("lbsProviderFallbackActivated")
-}

--- a/Navigation/Navigation/Service/LBS/Fallback/FallbackSearchService.swift
+++ b/Navigation/Navigation/Service/LBS/Fallback/FallbackSearchService.swift
@@ -9,12 +9,10 @@ final class FallbackSearchService: SearchProviding {
     let errorPublisher = PassthroughSubject<Error, Never>()
 
     private let primary: SearchProviding
-    private let fallback: SearchProviding
     private var cancellables = Set<AnyCancellable>()
 
-    init(primary: SearchProviding, fallback: SearchProviding) {
+    init(primary: SearchProviding) {
         self.primary = primary
-        self.fallback = fallback
         bindPrimary()
     }
 
@@ -24,7 +22,6 @@ final class FallbackSearchService: SearchProviding {
 
     func updateRegion(_ region: MKCoordinateRegion) {
         primary.updateRegion(region)
-        fallback.updateRegion(region)
     }
 
     func updateQuery(_ fragment: String) {
@@ -35,7 +32,8 @@ final class FallbackSearchService: SearchProviding {
         do {
             return try await primary.search(for: completion)
         } catch let error as LBSError where error == .quotaExceeded {
-            return try await fallback.search(query: completion.title, region: nil)
+            NotificationCenter.default.post(name: .lbsSearchQuotaExceeded, object: nil)
+            throw error
         }
     }
 
@@ -43,7 +41,8 @@ final class FallbackSearchService: SearchProviding {
         do {
             return try await primary.search(query: query, region: region, regionMode: regionMode)
         } catch let error as LBSError where error == .quotaExceeded {
-            return try await fallback.search(query: query, region: region, regionMode: regionMode)
+            NotificationCenter.default.post(name: .lbsSearchQuotaExceeded, object: nil)
+            throw error
         }
     }
 
@@ -51,7 +50,8 @@ final class FallbackSearchService: SearchProviding {
         do {
             return try await primary.searchCategory(category, region: region, regionMode: regionMode)
         } catch let error as LBSError where error == .quotaExceeded {
-            return try await fallback.search(query: category.query, region: region, regionMode: regionMode)
+            NotificationCenter.default.post(name: .lbsSearchQuotaExceeded, object: nil)
+            throw error
         }
     }
 
@@ -63,7 +63,6 @@ final class FallbackSearchService: SearchProviding {
 
     func cancelCurrentSearch() {
         primary.cancelCurrentSearch()
-        fallback.cancelCurrentSearch()
     }
 
     // MARK: - Private

--- a/Navigation/Navigation/Service/LBS/LBSServiceProvider.swift
+++ b/Navigation/Navigation/Service/LBS/LBSServiceProvider.swift
@@ -16,44 +16,80 @@ final class LBSServiceProvider {
 
     static let shared = LBSServiceProvider()
 
-    private(set) var providerType: LBSProviderType
+    private(set) var searchProviderType: LBSProviderType
+    private(set) var routeProviderType: LBSProviderType
 
     private(set) var search: SearchProviding
     private(set) var route: RouteProviding
     private(set) var geocoding: GeocodingProviding
 
     private init() {
-        let savedType = UserDefaults.standard.string(forKey: "lbs_provider")
+        // 마이그레이션: 기존 lbs_provider 키 → route_provider만 인계, search는 항상 kakao
+        if let legacy = UserDefaults.standard.string(forKey: "lbs_provider") {
+            UserDefaults.standard.set(legacy, forKey: "route_provider")
+            UserDefaults.standard.removeObject(forKey: "lbs_provider")
+        }
+
+        let savedSearch = UserDefaults.standard.string(forKey: "search_provider")
+            .flatMap(LBSProviderType.init(rawValue:)) ?? .kakao
+        let savedRoute = UserDefaults.standard.string(forKey: "route_provider")
             .flatMap(LBSProviderType.init(rawValue:)) ?? .apple
 
-        self.providerType = savedType
-        (search, route, geocoding) = Self.makeServices(for: savedType)
+        self.searchProviderType = savedSearch
+        self.routeProviderType = savedRoute
+        self.search = Self.makeSearchService(for: savedSearch)
+        self.route = Self.makeRouteService(for: savedRoute)
+        self.geocoding = Self.makeGeocodingService(for: savedSearch)
     }
 
-    func switchProvider(to type: LBSProviderType) {
-        guard type != providerType else { return }
-        UserDefaults.standard.set(type.rawValue, forKey: "lbs_provider")
-        providerType = type
-        (search, route, geocoding) = Self.makeServices(for: type)
+    func switchSearchProvider(to type: LBSProviderType) {
+        guard type != searchProviderType else { return }
+        UserDefaults.standard.set(type.rawValue, forKey: "search_provider")
+        searchProviderType = type
+        search = Self.makeSearchService(for: type)
+        geocoding = Self.makeGeocodingService(for: type)
+        NotificationCenter.default.post(name: .lbsSearchProviderChanged, object: nil)
+    }
+
+    func switchRouteProvider(to type: LBSProviderType) {
+        guard type != routeProviderType else { return }
+        UserDefaults.standard.set(type.rawValue, forKey: "route_provider")
+        routeProviderType = type
+        route = Self.makeRouteService(for: type)
     }
 
     // MARK: - Private
 
-    private static func makeServices(
-        for type: LBSProviderType
-    ) -> (SearchProviding, RouteProviding, GeocodingProviding) {
+    private static func makeSearchService(for type: LBSProviderType) -> SearchProviding {
         switch type {
-        case .apple:
-            return (AppleSearchService(), AppleRouteService(), AppleGeocodingService())
         case .kakao:
-            let appleSearch = AppleSearchService()
-            let appleRoute = AppleRouteService()
-            let appleGeocoding = AppleGeocodingService()
-            return (
-                FallbackSearchService(primary: KakaoSearchService(), fallback: appleSearch),
-                FallbackRouteService(primary: KakaoRouteService(), fallback: appleRoute),
-                FallbackGeocodingService(primary: KakaoGeocodingService(), fallback: appleGeocoding)
-            )
+            return FallbackSearchService(primary: KakaoSearchService())
+        case .apple:
+            return AppleSearchService()
         }
     }
+
+    private static func makeRouteService(for type: LBSProviderType) -> RouteProviding {
+        switch type {
+        case .kakao:
+            return FallbackRouteService(primary: KakaoRouteService(), fallback: AppleRouteService())
+        case .apple:
+            return AppleRouteService()
+        }
+    }
+
+    private static func makeGeocodingService(for type: LBSProviderType) -> GeocodingProviding {
+        switch type {
+        case .kakao:
+            return FallbackGeocodingService(primary: KakaoGeocodingService(), fallback: AppleGeocodingService())
+        case .apple:
+            return AppleGeocodingService()
+        }
+    }
+}
+
+extension Notification.Name {
+    static let lbsSearchProviderChanged = Notification.Name("lbsSearchProviderChanged")
+    static let lbsSearchQuotaExceeded = Notification.Name("lbsSearchQuotaExceeded")
+    static let lbsRouteFallbackActivated = Notification.Name("lbsRouteFallbackActivated")
 }


### PR DESCRIPTION
## 개요

LBS(위치 기반 서비스) provider를 검색과 경로로 독립 분리하고,
카카오 API 한도 초과 시 사용자에게 팝업으로 알리는 기능을 추가합니다.

## 배경

기존에는 검색/경로 제공자를 단일 설정(Kakao/Apple)으로 통합 관리했습니다.
API 전략 변경으로 검색은 Kakao(한국 POI 품질 우선), 경로는 Apple(도보 제휴 불필요)을
기본값으로 하되 각각 독립적으로 선택 가능하도록 변경합니다.

## 주요 변경 사항

### LBS Provider 분리
- `LBSServiceProvider`: 단일 `providerType` → `searchProviderType` + `routeProviderType` 독립 분리
- 기본값: 검색=Kakao, 경로=Apple
- 기존 `lbs_provider` UserDefaults 키 마이그레이션 (`route_provider`만 인계, 검색은 Kakao 기본값)

### 개발자 메뉴 (설정 → 개발자 메뉴 → 위치 서비스)
- "검색/경로 제공자" 단일 항목 → "검색 제공자" / "경로 제공자" 2개 독립 항목으로 분리
- SettingsViewController에서 DevToolsViewController로 이동

### 카카오 검색 한도 초과(429) 처리
- 기존: Apple로 조용히 폴백 (사용자 인지 불가)
- 변경: Apple 폴백 없이 팝업 표시 ("오늘 카카오 검색 한도에 도달했습니다")
- 매 초과 시마다 팝업 표시 — 사용자가 검색 실패 원인을 명확히 인지 가능

### 카카오 경로 한도 초과(429) 처리
- Apple 폴백은 기존대로 유지
- 폴백 전환 시 팝업 추가 ("카카오 경로 서비스가 일시적으로 제한됩니다")

### 검색 제공자 변경 시 즉시 반영
- `SearchViewModel`: provider 변경 감지 → searchService 교체 및 publisher rebind
- `HomeDrawerViewController`: 주변검색 카테고리 즉시 갱신 (Kakao 18개 ↔ Apple 20개)

## 기술 이슈 수정
- 429 팝업 핸들러에 `DispatchQueue.main.async` 추가 (백그라운드 스레드 UIKit 호출 방지)
- `FallbackSearchService` fallback 파라미터 제거 (quota 폴백 제거로 불필요)
- `Notification.Name` 정의를 `LBSServiceProvider.swift` 한 곳으로 통합
