### PR TITLE
feat(home): 좌측 데이터 레이어 버튼 메뉴 정리

### DIFF
--- a/Navigation/Navigation/Feature/Home/HomeViewController.swift
+++ b/Navigation/Navigation/Feature/Home/HomeViewController.swift
@@ -9,6 +9,9 @@ final class HomeViewController: UIViewController {
     private var mapControlButtons: MapControlButtonsView!
     private(set) var mapControlBottomConstraint: NSLayoutConstraint!
     private var compassButton: MKCompassButton!
+    private var layerButtons: MapLayerButtonsView!   // 좌측 데이터 레이어 (따릉이·버스·혼잡)
+    /// 애플 지도 로고·법적표기 위로 버튼을 띄우는 하단 여백
+    private let mapAttributionClearance: CGFloat = 28
 
     private let viewModel: HomeViewModel
     private let bikeViewModel = BikeViewModel()
@@ -45,6 +48,7 @@ final class HomeViewController: UIViewController {
         setupMapChild()
         setupCompassButton()
         setupMapControlButtons()
+        setupLayerButtons()
         setupDrawerContainer()
         bindViewModel()
         handleInitialPermission()
@@ -83,7 +87,7 @@ final class HomeViewController: UIViewController {
 
         mapControlBottomConstraint = buttons.bottomAnchor.constraint(
             equalTo: view.safeAreaLayoutGuide.bottomAnchor,
-            constant: -(200 + Theme.Spacing.md)
+            constant: -(200 + Theme.Spacing.md + mapAttributionClearance)
         )
 
         NSLayoutConstraint.activate([
@@ -99,28 +103,34 @@ final class HomeViewController: UIViewController {
         buttons.onMapModeTapped = { [weak self] in
             self?.handleMapModeTapped()
         }
-        buttons.onBikeRefreshTapped = { [weak self] in
-            self?.handleBikeRefreshTapped()
-        }
-        buttons.onPOILayerTapped = { [weak self] in
-            self?.handlePOILayerTapped()
-        }
-        buttons.onLivePulseTapped = { [weak self] in
-            self?.toggleLivePulse()
-        }
 
         mapViewController.onTrackingModeChanged = { [weak self] mode in
             self?.mapControlButtons.updateCurrentLocationIcon(for: mode)
         }
+    }
 
-        // 따릉이 레이어 ON/OFF → 버튼 시각 상태 갱신 + 지도 마커 동기화
+    /// 좌측 데이터 레이어 버튼 (따릉이·버스 = 오버레이 | 실시간 혼잡 = 모드).
+    /// 우측 지도조작 버튼과 세로 위치를 맞춤(bottom 동기).
+    private func setupLayerButtons() {
+        let bar = MapLayerButtonsView()
+        self.layerButtons = bar
+        view.addSubview(bar)
+        NSLayoutConstraint.activate([
+            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Theme.Spacing.lg),
+            bar.bottomAnchor.constraint(equalTo: mapControlButtons.bottomAnchor),
+        ])
+        bar.onBike = { [weak self] in Task { await self?.bikeViewModel.toggleLayer() } }
+        bar.onBus = { [weak self] in self?.busViewModel.toggleLayer() }
+        bar.onCongestion = { [weak self] in self?.toggleLivePulse() }
+        bar.onBikeRefresh = { [weak self] in self?.handleBikeRefreshTapped() }
+
+        // 따릉이 레이어 ON/OFF → 버튼 상태 + 지도 마커 동기화
         bikeViewModel.$isLayerOn
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isOn in
                 guard let self else { return }
-                self.mapControlButtons.updateBikeLayerState(isOn: isOn)
+                self.layerButtons.setBike(on: isOn)
                 if isOn {
-                    // 캐시에 데이터가 있으면 즉시 마커 표시 (재 fetch 안 함)
                     self.mapViewController.setBikeStations(BikeStationCache.shared.stations.value)
                 } else {
                     self.mapViewController.clearBikeStations()
@@ -128,7 +138,7 @@ final class HomeViewController: UIViewController {
             }
             .store(in: &cancellables)
 
-        // 캐시 변경 시 마커 동기화 (단, 레이어 ON 일 때만)
+        // 캐시 변경 시 마커 동기화 (레이어 ON 일 때만)
         BikeStationCache.shared.stations
             .receive(on: DispatchQueue.main)
             .sink { [weak self] stations in
@@ -145,23 +155,18 @@ final class HomeViewController: UIViewController {
                 guard let self else { return }
                 if isOn { self.mapViewController.setBusStops(stops) }
                 else { self.mapViewController.clearBusStops() }
-                self.updatePOIButtonState()
+                self.layerButtons.setBus(on: isOn)
             }
             .store(in: &cancellables)
 
         // 따릉이 정류소 마커 탭은 AppCoordinator 가 직접 mapViewController.onBikeStationSelected 처리
     }
 
-    private func updatePOIButtonState() {
-        let hasActive = bikeViewModel.isLayerOn || busViewModel.isLayerOn
-        mapControlButtons.updatePOILayerState(hasActiveLayer: hasActive)
-    }
-
     // MARK: - Live Pulse (실시간 혼잡)
 
     private func toggleLivePulse() {
         isLivePulseOn.toggle()
-        mapControlButtons.updateLivePulseState(isOn: isLivePulseOn)
+        layerButtons.setCongestion(on: isLivePulseOn)
 
         guard isLivePulseOn else {
             mapViewController.clearCongestion()
@@ -172,7 +177,7 @@ final class HomeViewController: UIViewController {
         }
         guard let service = citydataService, let catalog = hotspotCatalog else {
             isLivePulseOn = false
-            mapControlButtons.updateLivePulseState(isOn: false)
+            layerButtons.setCongestion(on: false)
             return
         }
         hideOverlayLayers()          // 진입 시 겹치는 POI 레이어 임시 OFF (배타)
@@ -316,33 +321,11 @@ final class HomeViewController: UIViewController {
         return "\(period) \(h12)시"
     }
 
-    private func handlePOILayerTapped() {
-        let alert = UIAlertController(title: "지도 레이어", message: nil, preferredStyle: .actionSheet)
-
-        let bikeTitle = bikeViewModel.isLayerOn ? "✓ 따릉이" : "따릉이"
-        alert.addAction(UIAlertAction(title: bikeTitle, style: .default) { [weak self] _ in
-            Task { await self?.bikeViewModel.toggleLayer() }
-        })
-
-        let busTitle = busViewModel.isLayerOn ? "✓ 버스 정류소" : "버스 정류소"
-        alert.addAction(UIAlertAction(title: busTitle, style: .default) { [weak self] _ in
-            self?.busViewModel.toggleLayer()
-        })
-
-        alert.addAction(UIAlertAction(title: "닫기", style: .cancel))
-
-        if let popover = alert.popoverPresentationController {
-            popover.sourceView = mapControlButtons
-            popover.sourceRect = mapControlButtons.bounds
-        }
-        present(alert, animated: true)
-    }
-
     private func handleBikeRefreshTapped() {
-        mapControlButtons.setBikeRefreshing(true)
+        layerButtons.setBikeRefreshing(true)
         Task { [weak self] in
             await self?.bikeViewModel.fetchAll()
-            self?.mapControlButtons.setBikeRefreshing(false)
+            self?.layerButtons.setBikeRefreshing(false)
         }
     }
 
@@ -395,7 +378,7 @@ final class HomeViewController: UIViewController {
 
     func updateMapControlBottomOffset(_ height: CGFloat) {
         UIView.animate(withDuration: 0.3) {
-            self.mapControlBottomConstraint.constant = -(height + Theme.Spacing.md)
+            self.mapControlBottomConstraint.constant = -(height + Theme.Spacing.md + self.mapAttributionClearance)
             self.view.layoutIfNeeded()
         }
     }

--- a/Navigation/Navigation/Feature/Home/MapControlButtonsView.swift
+++ b/Navigation/Navigation/Feature/Home/MapControlButtonsView.swift
@@ -1,15 +1,14 @@
 import UIKit
 import MapKit
 
+/// 우측 지도 조작 버튼 (뷰 컨트롤 전용 — 현재위치·지도유형).
+/// 데이터 레이어(따릉이·버스·혼잡)는 상단 `MapLayerChipBar`로 분리.
 final class MapControlButtonsView: UIView {
 
     // MARK: - Callbacks
 
     var onCurrentLocationTapped: (() -> Void)?
     var onMapModeTapped: (() -> Void)?
-    var onBikeRefreshTapped: (() -> Void)?
-    var onPOILayerTapped: (() -> Void)?
-    var onLivePulseTapped: (() -> Void)?
 
     // MARK: - UI
 
@@ -23,9 +22,6 @@ final class MapControlButtonsView: UIView {
 
     private let currentLocationButton = UIButton(type: .system)
     private let mapModeButton = UIButton(type: .system)
-    private let bikeRefreshButton = UIButton(type: .system)
-    private let poiLayerButton = UIButton(type: .system)
-    private let livePulseButton = UIButton(type: .system)
 
     // MARK: - Init
 
@@ -52,28 +48,11 @@ final class MapControlButtonsView: UIView {
         configureButton(mapModeButton, iconName: "map")
         stackView.addArrangedSubview(mapModeButton)
 
-        // POI 레이어 버튼 — 따릉이/버스 토글 팝업 진입
-        configureButton(poiLayerButton, iconName: "square.3.layers.3d")
-        stackView.addArrangedSubview(poiLayerButton)
-
-        // 실시간 혼잡(Live Pulse) 진입 버튼
-        configureButton(livePulseButton, iconName: "waveform.path.ecg")
-        stackView.addArrangedSubview(livePulseButton)
-
-        // 새로고침 버튼 — 따릉이 ON 일 때만 노출. stackView 바깥에서 POI 버튼 좌측에 별도 배치
-        configureButton(bikeRefreshButton, iconName: "arrow.clockwise")
-        bikeRefreshButton.isHidden = true
-        addSubview(bikeRefreshButton)
-
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-            // refresh 는 POI 레이어 버튼의 좌측에 배치
-            bikeRefreshButton.trailingAnchor.constraint(equalTo: poiLayerButton.leadingAnchor, constant: -Theme.Spacing.sm),
-            bikeRefreshButton.centerYAnchor.constraint(equalTo: poiLayerButton.centerYAnchor),
         ])
     }
 
@@ -101,9 +80,6 @@ final class MapControlButtonsView: UIView {
     private func setupActions() {
         currentLocationButton.addTarget(self, action: #selector(currentLocationTapped), for: .touchUpInside)
         mapModeButton.addTarget(self, action: #selector(mapModeTapped), for: .touchUpInside)
-        bikeRefreshButton.addTarget(self, action: #selector(bikeRefreshTapped), for: .touchUpInside)
-        poiLayerButton.addTarget(self, action: #selector(poiLayerTapped), for: .touchUpInside)
-        livePulseButton.addTarget(self, action: #selector(livePulseTapped), for: .touchUpInside)
     }
 
     private func setupAccessibility() {
@@ -112,12 +88,6 @@ final class MapControlButtonsView: UIView {
 
         mapModeButton.accessibilityLabel = "지도 모드"
         mapModeButton.accessibilityHint = "지도 표시 유형을 변경합니다"
-
-        bikeRefreshButton.accessibilityLabel = "따릉이 새로고침"
-        bikeRefreshButton.accessibilityHint = "따릉이 정류소 정보를 새로고침합니다"
-
-        poiLayerButton.accessibilityLabel = "POI 레이어"
-        poiLayerButton.accessibilityHint = "따릉이, 버스 표시를 설정합니다"
     }
 
     // MARK: - Actions
@@ -128,23 +98,6 @@ final class MapControlButtonsView: UIView {
 
     @objc private func mapModeTapped() {
         onMapModeTapped?()
-    }
-
-    @objc private func bikeRefreshTapped() {
-        onBikeRefreshTapped?()
-    }
-
-    @objc private func poiLayerTapped() {
-        onPOILayerTapped?()
-    }
-
-    @objc private func livePulseTapped() {
-        onLivePulseTapped?()
-    }
-
-    /// 실시간 혼잡 모드 ON/OFF 시각 상태
-    func updateLivePulseState(isOn: Bool) {
-        livePulseButton.tintColor = isOn ? Theme.Colors.primary : Theme.Colors.secondaryLabel
     }
 
     // MARK: - State Updates
@@ -175,37 +128,10 @@ final class MapControlButtonsView: UIView {
 
     func updateMapModeIcon(isSatellite: Bool) {
         let iconName = isSatellite ? "globe.americas.fill" : "map"
-
         mapModeButton.setImage(
             UIImage(systemName: iconName)?
                 .withConfiguration(UIImage.SymbolConfiguration(pointSize: Theme.Card.iconSize, weight: .medium)),
             for: .normal
         )
-    }
-
-    func updateBikeLayerState(isOn: Bool) {
-        // 따릉이 레이어 ON 일 때만 새로고침 버튼 노출
-        bikeRefreshButton.isHidden = !isOn
-    }
-
-    func setBikeRefreshing(_ refreshing: Bool) {
-        bikeRefreshButton.isEnabled = !refreshing
-        let alpha: CGFloat = refreshing ? 0.4 : 1
-        bikeRefreshButton.alpha = alpha
-    }
-
-    func updatePOILayerState(hasActiveLayer: Bool) {
-        poiLayerButton.tintColor = hasActiveLayer ? Theme.Colors.primary : Theme.Colors.secondaryLabel
-    }
-
-    // bikeRefreshButton 은 self 의 bounds 좌측 밖에 배치되어 있어 기본 hitTest 로는 탭이 통과됨.
-    // 보이는 영역(노출 중 + 활성) 일 때만 hit 으로 확장.
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        if super.point(inside: point, with: event) { return true }
-        if !bikeRefreshButton.isHidden, bikeRefreshButton.isEnabled {
-            let p = convert(point, to: bikeRefreshButton)
-            if bikeRefreshButton.bounds.contains(p) { return true }
-        }
-        return false
     }
 }

--- a/Navigation/Navigation/Feature/Home/MapLayerButtonsView.swift
+++ b/Navigation/Navigation/Feature/Home/MapLayerButtonsView.swift
@@ -1,0 +1,137 @@
+import UIKit
+
+/// 좌측 데이터 레이어 버튼 (아이콘 전용 — 우측 지도조작 버튼과 동일 디자인).
+/// 따릉이·버스 = 오버레이 토글 / 실시간 혼잡 = 모드. 혼잡 ON 시 오버레이는 disable.
+/// 따릉이 새로고침은 따릉이 버튼에 종속 배치(따릉이 ON일 때 우측에 등장).
+final class MapLayerButtonsView: UIView {
+
+    // MARK: - Callbacks
+    var onBike: (() -> Void)?
+    var onBus: (() -> Void)?
+    var onCongestion: (() -> Void)?
+    var onBikeRefresh: (() -> Void)?
+
+    // MARK: - Buttons
+    private let bikeButton = UIButton(type: .system)
+    private let busButton = UIButton(type: .system)
+    private let congestionButton = UIButton(type: .system)
+    private let refreshButton = UIButton(type: .system)
+
+    private var bikeOn = false
+    private var congestionOn = false
+
+    private let stack: UIStackView = {
+        let s = UIStackView()
+        s.translatesAutoresizingMaskIntoConstraints = false
+        s.axis = .vertical
+        s.alignment = .leading
+        s.spacing = Theme.Spacing.sm
+        return s
+    }()
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        translatesAutoresizingMaskIntoConstraints = false
+        setup()
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    private func setup() {
+        configureButton(bikeButton, icon: "bicycle")
+        configureButton(busButton, icon: "bus")
+        configureButton(congestionButton, icon: "chart.bar.xaxis")
+        configureButton(refreshButton, icon: "arrow.clockwise")
+        refreshButton.isHidden = true
+
+        // 따릉이 행: [따릉이] [새로고침] — 새로고침은 따릉이에 종속
+        let bikeRow = UIStackView(arrangedSubviews: [bikeButton, refreshButton])
+        bikeRow.axis = .horizontal
+        bikeRow.spacing = Theme.Spacing.sm
+
+        // 순서: 혼잡 ↑ / 버스 / 따릉이(+새로고침) ↓ — 새로고침이 붙는 따릉이를 맨 아래로
+        stack.addArrangedSubview(congestionButton)
+        stack.addArrangedSubview(busButton)
+        stack.addArrangedSubview(bikeRow)
+        addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+
+        bikeButton.addTarget(self, action: #selector(bikeTapped), for: .touchUpInside)
+        busButton.addTarget(self, action: #selector(busTapped), for: .touchUpInside)
+        congestionButton.addTarget(self, action: #selector(congestionTapped), for: .touchUpInside)
+        refreshButton.addTarget(self, action: #selector(refreshTapped), for: .touchUpInside)
+
+        setActive(bikeButton, on: false)
+        setActive(busButton, on: false)
+        setActive(congestionButton, on: false)
+
+        bikeButton.accessibilityLabel = "따릉이 표시"
+        busButton.accessibilityLabel = "버스 정류소 표시"
+        congestionButton.accessibilityLabel = "실시간 혼잡"
+        refreshButton.accessibilityLabel = "따릉이 새로고침"
+    }
+
+    // MARK: - Actions
+    @objc private func bikeTapped() { onBike?() }
+    @objc private func busTapped() { onBus?() }
+    @objc private func congestionTapped() { onCongestion?() }
+    @objc private func refreshTapped() { onBikeRefresh?() }
+
+    // MARK: - State
+    func setBike(on: Bool) {
+        bikeOn = on
+        setActive(bikeButton, on: on)
+        refreshButton.isHidden = !(on && !congestionOn)
+    }
+    func setBus(on: Bool) { setActive(busButton, on: on) }
+
+    /// 혼잡 ON → 오버레이(따릉이·버스·새로고침) 숨김, OFF → 복원. 애니메이션.
+    func setCongestion(on: Bool) {
+        congestionOn = on
+        setActive(congestionButton, on: on)
+        UIView.animate(withDuration: 0.25) {
+            self.bikeButton.isHidden = on
+            self.busButton.isHidden = on
+            self.refreshButton.isHidden = on || !self.bikeOn
+            self.bikeButton.alpha = on ? 0 : 1
+            self.busButton.alpha = on ? 0 : 1
+            self.refreshButton.alpha = on ? 0 : 1
+            self.superview?.layoutIfNeeded()
+        }
+    }
+    func setBikeRefreshing(_ refreshing: Bool) {
+        refreshButton.isEnabled = !refreshing
+        refreshButton.alpha = refreshing ? 0.4 : 1
+    }
+
+    // MARK: - 스타일 (우측 MapControlButtonsView와 동일)
+    private func configureButton(_ button: UIButton, icon: String) {
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(
+            UIImage(systemName: icon)?
+                .withConfiguration(UIImage.SymbolConfiguration(pointSize: Theme.Card.iconSize, weight: .medium)),
+            for: .normal
+        )
+        button.tintColor = Theme.Colors.secondaryLabel
+        button.backgroundColor = Theme.Card.backgroundColor.withAlphaComponent(Theme.Card.backgroundOpacity)
+        button.layer.cornerRadius = Theme.Card.cornerRadius
+        button.layer.shadowColor = Theme.Shadow.color
+        button.layer.shadowOpacity = Theme.Shadow.opacity
+        button.layer.shadowOffset = Theme.Shadow.offset
+        button.layer.shadowRadius = Theme.Shadow.radius
+        NSLayoutConstraint.activate([
+            button.widthAnchor.constraint(equalToConstant: Theme.Card.size),
+            button.heightAnchor.constraint(equalToConstant: Theme.Card.size),
+        ])
+    }
+
+    private func setActive(_ button: UIButton, on: Bool) {
+        button.tintColor = on ? Theme.Colors.primary : Theme.Colors.secondaryLabel
+    }
+}


### PR DESCRIPTION
## 개요
홈 지도의 컨트롤 메뉴를 심플·명확하게 재정리합니다. 데이터 레이어(혼잡·버스·따릉이)를
좌측 아이콘 버튼으로 분리하고, 우측은 순수 뷰 컨트롤(현재위치·지도유형)만 담당하도록 축소했습니다.

## 변경 사항
### 신규 — 좌측 데이터 레이어 버튼 (`MapLayerButtonsView`)
- 아이콘 전용 버튼: **혼잡 · 버스 · 따릉이(+새로고침)** — 우측 `MapControlButtonsView`와 동일 디자인
- **실시간 혼잡 ON** 시 버스·따릉이 버튼을 애니메이션으로 숨김, **OFF** 시 복원
- 새로고침 버튼을 따릉이에 **종속 배치** (따릉이 ON & 혼잡 OFF일 때만 노출)

### 정리 — `MapControlButtonsView`
- 데이터 레이어 관련 콜백/상태(POI·라이브펄스·따릉이 새로고침) 제거
- 뷰 컨트롤(현재위치·지도유형)만 유지

### 레이아웃
- 애플 지도 로고 가림 방지: 좌·우 지도 버튼 스택 하단에 여백(clearance) 추가

## 파일
| 파일 | 변경 |
|------|------|
| `Feature/Home/MapLayerButtonsView.swift` | 신규 |
| `Feature/Home/MapControlButtonsView.swift` | 축소 |
| `Feature/Home/HomeViewController.swift` | 배선·레이아웃 |

## 알려진 개선 여지 (후속)
- 혼잡 ON 시 `bikeRow` 래퍼 미숨김으로 인한 소폭 여백
- 혼잡 진입 시 혼잡 버튼이 하단으로 이동하는 애니메이션
- `configureButton` 스타일 좌/우 중복 → 공용 헬퍼화

## 테스트
- 좌측 버튼 토글(혼잡/버스/따릉이), 혼잡 ON/OFF 숨김·복원 애니메이션, 새로고침 노출 조건 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
