### PR TITLE
feat(home): 버스·따릉이 레이어 켤 때 정류소 표출 레벨로 자동 확대

### DIFF
--- a/Navigation/Navigation/Feature/Home/HomeViewController.swift
+++ b/Navigation/Navigation/Feature/Home/HomeViewController.swift
@@ -119,8 +119,19 @@ final class HomeViewController: UIViewController {
             bar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Theme.Spacing.lg),
             bar.bottomAnchor.constraint(equalTo: mapControlButtons.bottomAnchor),
         ])
-        bar.onBike = { [weak self] in Task { await self?.bikeViewModel.toggleLayer() } }
-        bar.onBus = { [weak self] in self?.busViewModel.toggleLayer() }
+        bar.onBike = { [weak self] in
+            Task {
+                guard let self else { return }
+                await self.bikeViewModel.toggleLayer()
+                // 켤 때 현재 줌이 정류소 표출 레벨보다 멀면 보이는 레벨로 확대 (중심 유지)
+                if self.bikeViewModel.isLayerOn { self.mapViewController.zoomToShowBikeStations() }
+            }
+        }
+        bar.onBus = { [weak self] in
+            guard let self else { return }
+            self.busViewModel.toggleLayer()
+            if self.busViewModel.isLayerOn { self.mapViewController.zoomToShowBusStops() }
+        }
         bar.onCongestion = { [weak self] in self?.toggleLivePulse() }
         bar.onBikeRefresh = { [weak self] in self?.handleBikeRefreshTapped() }
 

--- a/Navigation/Navigation/Map/MapViewController.swift
+++ b/Navigation/Navigation/Map/MapViewController.swift
@@ -738,6 +738,32 @@ final class MapViewController: UIViewController {
         }
     }
 
+    // MARK: - Layer Auto-Zoom
+
+    /// 따릉이 마커가 보이는 줌 레벨로 필요 시 확대 (중심 유지, 이미 충분히 확대면 no-op)
+    func zoomToShowBikeStations() {
+        zoomInIfNeeded(maxLatitudeDelta: Self.bikeMaxLatitudeDelta)
+    }
+
+    /// 버스 마커가 보이는 줌 레벨로 필요 시 확대 (중심 유지, 이미 충분히 확대면 no-op)
+    func zoomToShowBusStops() {
+        zoomInIfNeeded(maxLatitudeDelta: Self.busMaxLatitudeDelta)
+    }
+
+    /// 현재 줌이 임계값보다 축소돼 있으면 임계값 이하로 확대 (중심 유지). 확대만, 축소는 안 함.
+    /// 마커 표시 자체는 애니메이션 종료 후 `regionDidChangeAnimated` → visibility 갱신이 담당.
+    private func zoomInIfNeeded(maxLatitudeDelta: Double) {
+        let span = mapView.region.span
+        guard span.latitudeDelta > maxLatitudeDelta else { return }
+        // 임계값보다 살짝 더 확대해 경계 흔들림(latΔ ≈ 임계값) 방지
+        let ratio = (maxLatitudeDelta * 0.9) / span.latitudeDelta
+        let newSpan = MKCoordinateSpan(
+            latitudeDelta: span.latitudeDelta * ratio,
+            longitudeDelta: span.longitudeDelta * ratio
+        )
+        mapView.setRegion(MKCoordinateRegion(center: mapView.region.center, span: newSpan), animated: true)
+    }
+
     // MARK: - Route Focus Mode
 
     /// 노선 정보 보기 중 — 선택 정류장 외 버스/따릉이 마커를 숨겨 노선만 부각


### PR DESCRIPTION
## 배경
버스/따릉이 레이어를 켜면 정류소 마커가 지도에 추가되지만, 마커는 특정 줌
이상에서만 표시된다(따릉이 latΔ ≤ 0.05, 버스 ≤ 0.03). 축소된 상태에서 켜면
버튼은 ON 되는데 화면에 아무것도 안 보여 "왜 안 나오지?" 혼란이 있었다.

## 변경
레이어를 **켤 때** 현재 줌이 표출 임계값보다 멀면, **보던 지도 중심을 유지한 채**
표출 레벨로 부드럽게 확대한다.

- `MapViewController`
  - `zoomToShowBikeStations()` / `zoomToShowBusStops()` 추가
  - 내부 `zoomInIfNeeded(maxLatitudeDelta:)`: 현재 latΔ가 임계값보다 클 때만
    확대(축소는 안 함). 경계 흔들림(latΔ ≈ 임계값) 방지로 임계값의 0.9배까지 당김.
- `HomeViewController`
  - `onBike`/`onBus` 콜백에서 토글 후 **켜진 경우에만** 위 메서드 호출.

## 설계 포인트
- **탭 콜백에 배치**(상태 sink 아님) → 앱 시작 시 레이어 상태 복원에서는 줌이 튀지 않음.
- **중심 유지** → 사용자 위치로 튀지 않고 보던 영역만 확대.
- **조건부** → 이미 충분히 확대돼 있으면 no-op.
- 마커 표시는 기존 경로 유지 — 확대 애니메이션 종료 후 `regionDidChangeAnimated`가
  visibility를 갱신해 마커가 나타남.

## 대안 검토
- "게이팅 제거(항상 표시)"는 도시 레벨에서 정류소 수천 개가 겹쳐 성능·가독성이
  나빠져 제외.

## 파일
| 파일 | 변경 |
|------|------|
| `Map/MapViewController.swift` | 자동 확대 메서드 추가 |
| `Feature/Home/HomeViewController.swift` | 레이어 ON 시 확대 호출 |

## 테스트 (수동, 시뮬레이터)
- [x] 축소 상태에서 따릉이 켜기 → 제자리 확대 + 정류소 표시
- [x] 축소 상태에서 버스 켜기 → 더 당겨져 표시
- [x] 이미 확대된 상태에서 켜기 → 줌 안 움직이고 즉시 표시
- [x] 켠 채로 앱 재실행 → 시작 시 원치 않는 줌 없음
- [x] `xcodebuild ... build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
