### PR TITLE
fix(home): 드로어 드래그 시 지도 버튼이 시차 없이 따라오도록 수정

### DIFF
--- a/Navigation/Navigation/Common/UI/DrawerContainerManager.swift
+++ b/Navigation/Navigation/Common/UI/DrawerContainerManager.swift
@@ -459,8 +459,8 @@ final class DrawerContainerManager: NSObject {
 
         animateTransition(in: parent, animated: true) {
             self.drawerStack[self.topIndex].heightConstraint.constant = targetHeight + parent.view.safeAreaInsets.bottom
+            self.onHeightChanged?(targetHeight)   // 스프링 블록 안에서 호출 → 버튼/inset이 함께 애니메이션
         } completion: {
-            self.onHeightChanged?(targetHeight)
             completion?()
         }
     }
@@ -475,8 +475,8 @@ final class DrawerContainerManager: NSObject {
 
         animateTransition(in: parent, animated: true) {
             self.drawerStack[self.topIndex].heightConstraint.constant = targetHeight + parent.view.safeAreaInsets.bottom
+            self.onHeightChanged?(targetHeight)   // 스프링 블록 안에서 호출 → 버튼/inset이 함께 애니메이션
         } completion: {
-            self.onHeightChanged?(targetHeight)
         }
     }
 

--- a/Navigation/Navigation/Feature/Home/HomeViewController.swift
+++ b/Navigation/Navigation/Feature/Home/HomeViewController.swift
@@ -387,11 +387,11 @@ final class HomeViewController: UIViewController {
 
     // MARK: - Map Control Position (called by coordinator)
 
+    /// 드로어 높이 콜백으로 매 프레임 호출됨. 자체 애니메이션을 걸지 않고 constant만 갱신 →
+    /// 드래그 중엔 드로어 본체와 같은 레이아웃 패스에서 1:1로 따라오고(시차 제거),
+    /// 스냅 시엔 드로어의 스프링 애니메이션 블록 안에서 호출돼 함께 애니메이션된다.
     func updateMapControlBottomOffset(_ height: CGFloat) {
-        UIView.animate(withDuration: 0.3) {
-            self.mapControlBottomConstraint.constant = -(height + Theme.Spacing.md + self.mapAttributionClearance)
-            self.view.layoutIfNeeded()
-        }
+        mapControlBottomConstraint.constant = -(height + Theme.Spacing.md + mapAttributionClearance)
     }
 
     func updateMapInsets(top: CGFloat, bottom: CGFloat) {


### PR DESCRIPTION
## 문제
홈 드로어를 위아래로 드래그하면 지도 위 컨트롤 버튼(현재위치·지도유형·데이터
레이어)이 드로어를 즉시 따라오지 못하고 0.3초 정도 뒤늦게 쫓아왔다.

## 원인
드로어 높이 값은 드래그 "중" 매 프레임 연속 발행되는데, 버튼 위치 갱신 함수
`updateMapControlBottomOffset`가 그 값을 매번 새로운 `UIView.animate(0.3)`으로
감쌌다. 매 프레임 "0.3초에 걸쳐 새 목표로 이동"이 재시작되면서 버튼이 실제
목표에 닿기 전에 계속 덮어써지는 로우패스(스무딩) 효과 → 상시 뒤처짐.
반면 드로어 본체와 애플 로고(layoutMargins)는 즉시 반영이라 시차가 도드라졌다.

## 수정
- `HomeViewController.updateMapControlBottomOffset`: 자체 애니메이션 제거,
  constant만 갱신. 드래그 중 드로어 본체와 같은 레이아웃 패스에서 1:1로 따라옴.
- `DrawerContainerManager` 두 스냅 메서드: `onHeightChanged` 호출을 완료
  콜백에서 **스프링 애니메이션 블록 안**으로 이동. 손을 놓아 detent로 스냅될 때
  버튼/inset이 드로어의 스프링과 같은 곡선으로 함께 이동(예전엔 스프링이 끝난
  뒤에야 따로 움직임).

## 파일
| 파일 | 변경 |
|------|------|
| `Feature/Home/HomeViewController.swift` | 버튼 갱신 자체 애니메이션 제거 |
| `Common/UI/DrawerContainerManager.swift` | 스냅 시 콜백을 스프링 블록으로 이동 |

## 테스트 (수동, 시뮬레이터)
- [x] 드로어 천천히/빠르게 드래그 → 버튼이 시차 없이 붙어 따라옴
- [x] 손 놓아 스냅 → 버튼이 드로어 스프링과 함께 이동
- [x] `xcodebuild ... build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)
